### PR TITLE
Update train call in W&B project

### DIFF
--- a/integrations/wandb/README.md
+++ b/integrations/wandb/README.md
@@ -20,13 +20,14 @@ The following commands are defined by the project. They
 can be executed using [`spacy project run [name]`](https://nightly.spacy.io/api/cli#project-run).
 Commands are only re-run if their inputs have changed.
 
-| Command | Description |
-| --- | --- |
-| `install` | Install dependencies and log in to Weights & Biases |
-| `data` | Extract the gold-standard annotations |
-| `train` | Train a model using the default config |
+| Command          | Description                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `install`        | Install dependencies and log in to Weights & Biases                                                                              |
+| `data`           | Extract the gold-standard annotations                                                                                            |
+| `train`          | Train a model using the default config                                                                                           |
 | `configs-search` | Create variations of the initial, default file for IMDB sentiment classification using different combinations of hyperparameters |
-| `train-search` | Run customized training runs for hyperparameter search using the created configs |
+| `train-search`   | Run customized training runs for hyperparameter search using the created configs                                                 |
+| `clean`          | Remove intermediate files to start config preparation & training from a clean slate.                                             |
 
 ### ⏭ Workflows
 
@@ -35,9 +36,9 @@ can be executed using [`spacy project run [name]`](https://nightly.spacy.io/api/
 and will run the specified commands in order. Commands are only re-run if their
 inputs have changed.
 
-| Workflow | Steps |
-| --- | --- |
-| `log` | `data` &rarr; `train` |
+| Workflow           | Steps                                                |
+| ------------------ | ---------------------------------------------------- |
+| `log`              | `data` &rarr; `train`                                |
 | `parameter-search` | `data` &rarr; `configs-search` &rarr; `train-search` |
 
 ### 🗂 Assets
@@ -46,8 +47,8 @@ The following assets are defined by the project. They can
 be fetched by running [`spacy project assets`](https://nightly.spacy.io/api/cli#project-assets)
 in the project directory.
 
-| File | Source | Description |
-| --- | --- | --- |
-| `assets/aclImdb_v1.tar.gz` | URL | Movie Review Dataset for sentiment analysis by Maas et al., ACL 2011. |
+| File                       | Source | Description                                                           |
+| -------------------------- | ------ | --------------------------------------------------------------------- |
+| `assets/aclImdb_v1.tar.gz` | URL    | Movie Review Dataset for sentiment analysis by Maas et al., ACL 2011. |
 
 <!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/integrations/wandb/project.yml
+++ b/integrations/wandb/project.yml
@@ -57,7 +57,8 @@ commands:
   - name: "configs-search"
     help: "Create variations of the initial, default file for IMDB sentiment classification using different combinations of hyperparameters"
     script:
-      - "python ./scripts/customize_configs.py configs ${vars.default_config}"
+      - "mkdir -p configs/search"
+      - "python ./scripts/customize_configs.py configs/search configs/${vars.default_config}"
     deps:
       - "scripts/customize_configs.py"
       - "configs/${vars.default_config}"
@@ -65,8 +66,15 @@ commands:
   - name: "train-search"
     help: "Run customized training runs for hyperparameter search using the created configs"
     script:
-      - "python ./scripts/run_configs.py configs ${vars.default_config} training/"
+      - "python ./scripts/run_configs.py configs/search training/"
     deps:
       - "assets/aclImdb/train/"
       - "assets/aclImdb/test/"
       - "configs/"
+
+  - name: "clean"
+    help: "Remove intermediate files to start config preparation and training from a clean slate."
+    script:
+      - "rm -rf configs/search/*"
+      - "rm -rf training/*"
+      - "rm -rf wandb/*"

--- a/integrations/wandb/scripts/customize_configs.py
+++ b/integrations/wandb/scripts/customize_configs.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from thinc.api import Config
 
 
-def main(config_dir: Path, default_config: str):
-    cfg = Config().from_disk(config_dir / default_config, interpolate=False)
+def main(config_dir: Path, default_config: Path):
+    cfg = Config().from_disk(default_config, interpolate=False)
     # hyperparameter grid search
     i = 0
     for depth in [2, 4]:
@@ -17,7 +17,7 @@ def main(config_dir: Path, default_config: str):
                     cfg["components"]["textcat"]["model"]["ngram_size"] = ngram
                     cfg["components"]["tok2vec"]["model"]["encode"]["depth"] = depth
                     cfg.to_disk(config_dir / f"config_{i}.cfg")
-    print(f"Saved {i} configs")
+    print(f"Saved {i} configs to {config_dir}")
 
 
 if __name__ == "__main__":

--- a/integrations/wandb/scripts/run_configs.py
+++ b/integrations/wandb/scripts/run_configs.py
@@ -1,6 +1,6 @@
 import typer
 from pathlib import Path
-from spacy.cli.train import train
+from spacy.training.loop import train
 from spacy.training.initialize import init_nlp
 from spacy.util import load_config
 

--- a/integrations/wandb/scripts/run_configs.py
+++ b/integrations/wandb/scripts/run_configs.py
@@ -1,17 +1,23 @@
 import typer
 from pathlib import Path
 from spacy.cli.train import train
+from spacy.training.initialize import init_nlp
+from spacy.util import load_config
 
 
-def main(config_dir: Path, default_config: str, results_dir: Path):
+def main(config_dir: Path, results_dir: Path):
     """Run all config files instead of the default one.
     Ideally, these runs are parellellized instead of run in sequence."""
-    for config_file in config_dir.iterdir():
-        if config_file.name != default_config:
-            output_path = results_dir / config_file.stem
-            if not output_path.exists():
-                output_path.mkdir()
-            train(config_path=config_file, output_path=output_path)
+    if not config_dir.exists() or not config_dir.is_dir():
+        print(f"Could not read from folder {config_dir}")
+    for config_path in config_dir.iterdir():
+        print(f"Training on {config_path}")
+        config = load_config(config_path, interpolate=False)
+        nlp = init_nlp(config, use_gpu=False)
+        output_path = results_dir / config_path.stem
+        if not output_path.exists():
+            output_path.mkdir()
+        train(nlp, output_path, use_gpu=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The latest spaCy v3 RC doesn't have the `train` function in `spacy.cli.train` anymore - updating the code here accordingly.