### PR TITLE
fix: Fix text_cat_goemotions project init-vectors

### DIFF
--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -49,7 +49,7 @@ commands:
   - name: init-vectors
     help: Download vectors and convert to model
     script:
-      - "python -m spacy init model --vectors-loc assets/vectors.zip en assets/en_fasttext_vectors"
+      - "python -m spacy init vectors en assets/vectors.zip assets/en_fasttext_vectors"
     deps:
       - "assets/vectors.zip"
     outputs_no_cache:


### PR DESCRIPTION
Hello folks!

I was testing the text_cat_goemotions project. And the init-vectors command was not working.
It was throwing the following message: `Error: No such command 'model'.`

I noticed that the command changed (https://spacy.io/api/cli#init-vectors),
so I modified it accordingly. Seems to be working now.