### PR TITLE
remove cupy-cuda102 requirement

### DIFF
--- a/benchmarks/speed/requirements.txt
+++ b/benchmarks/speed/requirements.txt
@@ -1,6 +1,5 @@
 transformers>=3.4.0,<4.3.0
 spacy-transformers>=1.0.1,<1.1.0
-cupy-cuda102
 stanza>=1.0.0,<1.2.0
 flair>=0.6.0,<1.0.0
 ufal.udpipe


### PR DESCRIPTION
I assume this got committed by accident when running the project before? (cf https://github.com/explosion/projects/commit/0403ebd2e0a826d526c4bd462e5dda60ea92d6d4) 