### PR TITLE
Change command name to match docs

### DIFF
--- a/pipelines/tagger_parser_ud/README.md
+++ b/pipelines/tagger_parser_ud/README.md
@@ -18,7 +18,7 @@ Commands are only re-run if their inputs have changed.
 
 | Command | Description |
 | --- | --- |
-| `convert` | Convert the data to spaCy's format |
+| `preprocess` | Convert the data to spaCy's format |
 | `train` | Train UD_English-EWT |
 | `evaluate` | Evaluate on the test data and save the metrics |
 | `package` | Package the trained model so it can be installed |
@@ -33,7 +33,7 @@ inputs have changed.
 
 | Workflow | Steps |
 | --- | --- |
-| `all` | `convert` &rarr; `train` &rarr; `evaluate` &rarr; `package` |
+| `all` | `preprocess` &rarr; `train` &rarr; `evaluate` &rarr; `package` |
 
 ### 🗂 Assets
 

--- a/pipelines/tagger_parser_ud/project.yml
+++ b/pipelines/tagger_parser_ud/project.yml
@@ -26,16 +26,14 @@ assets:
 
 workflows:
   all:
-    - convert
+    - preprocess
     - train
     - evaluate
     - package
 
 commands:
-  - name: convert
+  - name: preprocess
     help: "Convert the data to spaCy's format"
-    # Make sure we specify the branch in the command string, so that the
-    # caching works correctly.
     script:
       - "mkdir -p corpus/${vars.treebank}"
       - "python -m spacy convert assets/${vars.treebank}/${vars.train_name}.conllu corpus/${vars.treebank}/ --converter conllu --n-sents 10 --merge-subtokens"


### PR DESCRIPTION
Docs refer to `preprocess` but it was called `convert` here.

Also removed a stale comment.