### PR TITLE
textcat_goemotions - creation of training directory on Windows causes error

### DIFF
--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -8,6 +8,8 @@ vars:
   gpu_id: -1
   # Change this to "bert" to use the transformer-based model
   config: "cnn"
+  # Training Directory
+  training_directory: "training"
 
 # These are the directories that the project needs. The project CLI will make
 # sure that they always exist.
@@ -72,7 +74,7 @@ commands:
   - name: train
     help: "Train a spaCy pipeline using the specified corpus and config"
     script:
-      - python -c "import os; os.makedirs(os.path.join('training', ${vars.config}))"
+      - python -c "import os; os.makedirs(os.path.join('${vars.training_directory}', '${vars.config}'))"
       - "python -m spacy train ./configs/${vars.config}.cfg -o training/${vars.config} --gpu-id ${vars.gpu_id}"
     deps:
       - "corpus/train.spacy"

--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -72,7 +72,7 @@ commands:
   - name: train
     help: "Train a spaCy pipeline using the specified corpus and config"
     script:
-      - "mkdir -p training/${vars.config}"
+      - python -c "import os; os.makedirs(os.path.join('training', ${vars.config}))"
       - "python -m spacy train ./configs/${vars.config}.cfg -o training/${vars.config} --gpu-id ${vars.gpu_id}"
     deps:
       - "corpus/train.spacy"

--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -8,8 +8,6 @@ vars:
   gpu_id: -1
   # Change this to "bert" to use the transformer-based model
   config: "cnn"
-  # Training Directory
-  training_directory: "training"
 
 # These are the directories that the project needs. The project CLI will make
 # sure that they always exist.
@@ -74,7 +72,7 @@ commands:
   - name: train
     help: "Train a spaCy pipeline using the specified corpus and config"
     script:
-      - python -c "import os; os.makedirs(os.path.join('${vars.training_directory}', '${vars.config}'))"
+      - python -c "import os; os.makedirs(os.path.join('training', '${vars.config}'))"
       - "python -m spacy train ./configs/${vars.config}.cfg -o training/${vars.config} --gpu-id ${vars.gpu_id}"
     deps:
       - "corpus/train.spacy"


### PR DESCRIPTION
When running the `textcat_goemotions` example via `python -m spacy project run all` on Windows 10, the creation of the `training` directory causes an error due to the path structure on windows. The change in this PR uses python `os.makedir` to create the directory to make it OS agnostic. This is my first time contributing to this repo, so please let me know if there are any additional contributor gates I need to follow. Thanks.  

The log of the original error seen is below:



```
ℹ Running workflow 'all'

================================= preprocess =================================
ℹ Skipping 'preprocess': nothing changed

=================================== train ===================================
Running command: mkdir -p training/cnn
Traceback (most recent call last):
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\__main__.py", line 4, in <module>
    setup_cli()
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\cli\_util.py", line 68, in setup_cli
    command(prog_name=COMMAND)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\typer\main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\cli\project\run.py", line 41, in project_run_cli
    project_run(project_dir, subcommand, overrides=overrides, force=force, dry=dry)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\cli\project\run.py", line 75, in project_run
    project_run(project_dir, cmd, force=force, dry=dry, capture=capture)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\cli\project\run.py", line 91, in project_run
    run_commands(cmd["script"], dry=dry, capture=capture)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\cli\project\run.py", line 174, in run_commands
    run_command(command, capture=capture)
  File "C:\Users\ctufts\Anaconda3\envs\spacy3\lib\site-packages\spacy\util.py", line 832, in run_command
    ) from None
FileNotFoundError: [E970] Can not execute command 'mkdir -p training/cnn'. Do you have 'mkdir' installed?
```