### PR TITLE
Change testb.spacy to test.spacy so ner benchmark works

### DIFF
--- a/benchmarks/ner_conll03/project.yml
+++ b/benchmarks/ner_conll03/project.yml
@@ -75,10 +75,10 @@ commands:
   - name: evaluate
     help: "Evaluate on the test data and save the metrics"
     script:
-      - "python -m spacy evaluate ./training/${vars.config}/model-best ./corpus/testb.spacy --output ./metrics/${vars.config}.json --gpu-id ${vars.gpu} --gold-preproc"
+      - "python -m spacy evaluate ./training/${vars.config}/model-best ./corpus/test.spacy --output ./metrics/${vars.config}.json --gpu-id ${vars.gpu} --gold-preproc"
     deps:
       - "training/${vars.config}/model-best"
-      - "corpus/testb.spacy"
+      - "corpus/test.spacy"
     outputs:
       - "metrics/${vars.config}.json"
 


### PR DESCRIPTION
In the CoNLL-03 named entity recognition benchmark, the test corpus is saved as `test.spacy` but it's later called as `testb.spacy` during the evaluation, which makes it fail. This PR fixes this issue.