### PR TITLE
Textcat_doc_issues Preprocessing Update (Discussion #8035)

### DIFF
--- a/tutorials/textcat_docs_issues/configs/config.cfg
+++ b/tutorials/textcat_docs_issues/configs/config.cfg
@@ -27,7 +27,7 @@ threshold = 0.5
 
 [components.textcat.model]
 @architectures = "spacy.TextCatEnsemble.v1"
-exclusive_classes = false
+exclusive_classes = true
 pretrained_vectors = null
 width = 64
 conv_depth = 2

--- a/tutorials/textcat_docs_issues/scripts/preprocess.py
+++ b/tutorials/textcat_docs_issues/scripts/preprocess.py
@@ -15,7 +15,11 @@ def main(
     for doc, eg in nlp.pipe(data_tuples, as_tuples=True):
         if eg["answer"] == "ignore":
             continue
-        doc.cats[eg["label"]] = eg["answer"] == "accept"
+
+        if eg["answer"] == "accept":
+            doc.cats = {"DOCUMENTATION": True, "N/A": False}
+        else:
+            doc.cats = {"DOCUMENTATION": False, "N/A": True}
         doc_bin.add(doc)
     doc_bin.to_disk(output_path)
     print(f"Processed {len(doc_bin)} documents: {output_path.name}")


### PR DESCRIPTION
I've updated the preprocessing script for the textcat_doc_issues tutorial to reflect the conversation in [Discussion #8035](https://github.com/explosion/spaCy/discussions/8035#discussioncomment-932932). In summary, a binary classification using textcat should have two labels for classification, otherwise textcat_multi needs to be used.  

The results below show the difference between the version currently in branch v3 and the proposed changes:
V3 (current):
```
================================== Results ==================================

TOK                 100.00
TEXTCAT (macro F)   52.94
SPEED               22241


=========================== Textcat F (per label) ===========================

                     P       R       F
DOCUMENTATION   100.00   36.00   52.94


======================== Textcat ROC AUC (per label) ========================

                ROC AUC
DOCUMENTATION      0.59
```

Proposed Changes in PR:
```
================================== Results ==================================

TOK                 100.00
TEXTCAT (macro F)   80.11
SPEED               26605


=========================== Textcat F (per label) ===========================

                    P       R       F
DOCUMENTATION   76.16   69.70   72.78
N/A             85.67   89.25   87.43


======================== Textcat ROC AUC (per label) ========================

                ROC AUC
DOCUMENTATION      0.85
N/A                0.85

✔ Saved results to training\metrics.json
```