### PR TITLE
Remove spaces from list of models

### DIFF
--- a/integrations/streamlit/project.yml
+++ b/integrations/streamlit/project.yml
@@ -6,7 +6,7 @@ vars:
   # The default text shown in the visualizer on load
   default_text: "Sundar Pichai is the CEO of Google."
   # A comma-separated list of paths or installed package names
-  models: "en_core_web_sm, en_core_web_lg, en_core_web_trf"
+  models: "en_core_web_sm,en_core_web_lg,en_core_web_trf"
 
 # These are the directories that the project needs. The project CLI will make
 # sure that they always exist.


### PR DESCRIPTION
The spaces cause this to not work on the command line. See:

https://github.com/explosion/spaCy/issues/8662