### PR TITLE
Cross-platform basic implementation of CLI commands

### DIFF
--- a/pipelines/tagger_parser_ud/project.yml
+++ b/pipelines/tagger_parser_ud/project.yml
@@ -35,13 +35,13 @@ commands:
   - name: preprocess
     help: "Convert the data to spaCy's format"
     script:
-      - "mkdir -p corpus/${vars.treebank}"
+      - "python utils/file.py mkdir corpus/${vars.treebank}"
       - "python -m spacy convert assets/${vars.treebank}/${vars.train_name}.conllu corpus/${vars.treebank}/ --converter conllu --n-sents 10 --merge-subtokens"
       - "python -m spacy convert assets/${vars.treebank}/${vars.dev_name}.conllu corpus/${vars.treebank}/ --converter conllu --n-sents 10 --merge-subtokens"
       - "python -m spacy convert assets/${vars.treebank}/${vars.test_name}.conllu corpus/${vars.treebank}/ --converter conllu --n-sents 10 --merge-subtokens"
-      - "mv corpus/${vars.treebank}/${vars.train_name}.spacy corpus/${vars.treebank}/train.spacy"
-      - "mv corpus/${vars.treebank}/${vars.dev_name}.spacy corpus/${vars.treebank}/dev.spacy"
-      - "mv corpus/${vars.treebank}/${vars.test_name}.spacy corpus/${vars.treebank}/test.spacy"
+      - "python utils/file.py mv corpus/${vars.treebank}/${vars.train_name}.spacy corpus/${vars.treebank}/train.spacy"
+      - "python utils/file.py mv corpus/${vars.treebank}/${vars.dev_name}.spacy corpus/${vars.treebank}/dev.spacy"
+      - "python utils/file.py mv corpus/${vars.treebank}/${vars.test_name}.spacy corpus/${vars.treebank}/test.spacy"
     deps:
       - "assets/${vars.treebank}/${vars.train_name}.conllu"
       - "assets/${vars.treebank}/${vars.dev_name}.conllu"
@@ -84,6 +84,6 @@ commands:
   - name: clean
     help: "Remove intermediate files"
     script:
-      - "rm -rf training/*"
-      - "rm -rf metrics/*"
-      - "rm -rf corpus/*"
+      - "python utils/file.py rm training/*"
+      - "python utils/file.py rm metrics/*"
+      - "python utils/file.py rm corpus/*"

--- a/pipelines/tagger_parser_ud/utils/file.py
+++ b/pipelines/tagger_parser_ud/utils/file.py
@@ -1,0 +1,61 @@
+import argparse
+import shutil
+from os import PathLike
+from pathlib import Path
+from typing import Union
+
+
+def mkdir(path: Union[PathLike, str]):
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def mv(src: Union[PathLike, str], dst: Union[PathLike, str]):
+    shutil.move(src, dst)
+
+
+def _rm(item: Path):
+    if item.is_file():
+        item.unlink()
+    elif item.is_dir():
+        shutil.rmtree(item)
+
+
+def rm(path: Union[PathLike, str]):
+    item = Path(path)
+
+    if path.endswith(r"*"):
+        parent = Path(path[:-1])
+        if parent.is_dir():
+            for desc in parent.rglob("*"):
+                _rm(desc)
+        else:
+            _rm(item)
+    else:
+        _rm(item)
+
+
+if __name__ == '__main__':
+    cparser = argparse.ArgumentParser(description="Utility functions for file manipulation in spaCy projects")
+    csubparsers = cparser.add_subparsers()
+
+    parser_mv = csubparsers.add_parser("mv",
+                                       help="Move or rename file. Destination directory will be created if"
+                                            " it does not exist yet")
+    parser_mv.set_defaults(func=mv)
+    parser_mv.add_argument("src", help="File to move")
+    parser_mv.add_argument("dst", help="Destination to move to")
+
+    parser_rm = csubparsers.add_parser("rm",
+                                       help="Remove file or directory. If the given path ends with * all files in its"
+                                            " parent directory will be removed.")
+    parser_rm.set_defaults(func=rm)
+    parser_rm.add_argument("path", help="Directory or file to remove")
+
+    parser_mkdir = csubparsers.add_parser("mkdir",  help="Creates a given directory (and its parents if needed).")
+    parser_mkdir.set_defaults(func=mkdir)
+    parser_mkdir.add_argument("path", help="Directory to create")
+
+    cargs = vars(cparser.parse_args())
+    func = cargs.pop("func")
+    func(**cargs)
+


### PR DESCRIPTION
This PR relates to the issue that I brought up [here](https://github.com/explosion/spaCy/issues/6957). Not all CLI commands are available on all platforms, so the project.yml is not cross-platform.

In this PR I implement cross-platform helper CLI functions for `rm`, `mkdir`, and `mv`. As you may notice, these are relatively basic and not at all as powerful as native commands. But they do work as a stand-in replacement for the original commands.

This PR can serve as a template for the other projects as well, because here I only update the `tagger_parser_ud` project but I do not have the time to update all other projects.