### PR TITLE
Add wheel to azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
           - script: |
                 pip install "spacy>=3.0.1,<3.2.0"
                 pip install pytest
+                pip install wheel
                 pip install "numpy<1.20.0"
                 pip install "spacy_lookups_data>=1.0.2,<1.1.0"
                 pip install torch==1.7.1+cpu -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
## Issue
Projects that include `package` with `--build-wheel` in their workflow, fail the azure tests because `wheel` is not installed

## Change/Fix
- Add `wheel` as dependency in the `azure-pipeline.yml`