### PR TITLE
remove makedirs command that wasn't working

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
                 architecture: 'x64'
 
           - script: |
-                pip install "spacy>=3.0.1,<3.2.0"
+                pip install "spacy>=3.1.0,<3.2.0"
                 pip install pytest
                 pip install "numpy<1.20.0"
                 pip install "spacy_lookups_data>=1.0.2,<1.1.0"

--- a/experimental/ner_spancat/project.yml
+++ b/experimental/ner_spancat/project.yml
@@ -1,6 +1,6 @@
 title: "Example SpanCategorizer project using Indonesian NER"
 description: "The SpanCategorizer is a component in **spaCy v3.1+** for assigning labels to contiguous spans of text proposed by a customizable suggester function. Unlike spaCy's EntityRecognizer component, the SpanCategorizer can recognize nested or overlapping spans. It also doesn't rely as heavily on consistent starting and ending words, so it may be a better fit for non-NER span labelling tasks. You do have to write a function that proposes your candidate spans, however. If your spans are often short, you could propose all spans under a certain size. You could also use syntactic constituents such as noun phrases or noun chunks, or matcher rules."
-spacy_version: "3.1.0,<4.0.0"
+spacy_version: ">=3.1.0,<4.0.0"
 
 vars:
   config: "spancat"  # "ner"

--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -72,7 +72,6 @@ commands:
   - name: train
     help: "Train a spaCy pipeline using the specified corpus and config"
     script:
-      - python -c "import os; os.makedirs(os.path.join('training', '${vars.config}'))"
       - "python -m spacy train ./configs/${vars.config}.cfg -o training/${vars.config} --gpu-id ${vars.gpu_id}"
     deps:
       - "corpus/train.spacy"


### PR DESCRIPTION
Revert PR https://github.com/explosion/projects/pull/42 - cf https://github.com/explosion/spaCy/issues/6957#issuecomment-872403914

We didn't actually need the `mkdir` statement there as `spacy train` takes care of this.

Adding 2 small fixes for spaCy versions here as well.