### PR TITLE
Fix issue with RelEx scoring

### DIFF
--- a/tutorials/rel_component/scripts/rel_pipe.py
+++ b/tutorials/rel_component/scripts/rel_pipe.py
@@ -208,7 +208,7 @@ def score_relations(examples: Iterable[Example], threshold: float) -> Dict[str, 
         gold = example.reference._.rel
         pred = example.predicted._.rel
         for key, pred_dict in pred.items():
-            gold_labels = [k for (k, v) in gold[key].items() if v == 1.0]
+            gold_labels = [k for (k, v) in gold.get(key, {}).items() if v == 1.0]
             for k, v in pred_dict.items():
                 if v >= threshold:
                     if k in gold_labels:


### PR DESCRIPTION
A couple of users have gotten errors in relation extraction because their entities at runtime differ from those in their gold data. This is a fix indicated in [this issue](https://github.com/explosion/spaCy/discussions/9222#discussioncomment-1355925) that simply treats any pairs not mentioned in the gold data as wrong. 