### PR TITLE
Update all configs to use Tok2Vec.v2 instead of v1

### DIFF
--- a/benchmarks/ner_conll03/configs/cnn_glove_small.cfg
+++ b/benchmarks/ner_conll03/configs/cnn_glove_small.cfg
@@ -46,7 +46,7 @@ rows = [5000,2500,2500,2500]
 include_static_vectors = true
 
 [components.ner.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 128
 depth = 4
 window_size = 1

--- a/benchmarks/ner_conll03/configs/cnn_glove_small.cfg
+++ b/benchmarks/ner_conll03/configs/cnn_glove_small.cfg
@@ -36,7 +36,7 @@ use_upper = true
 nO = null
 
 [components.ner.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.ner.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/benchmarks/parsing_penn_treebank/configs/cnn_glove_small.cfg
+++ b/benchmarks/parsing_penn_treebank/configs/cnn_glove_small.cfg
@@ -48,7 +48,7 @@ rows = [5000,2500,2500,2500]
 include_static_vectors = true
 
 [components.parser.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 128
 depth = 4
 window_size = 1

--- a/benchmarks/parsing_penn_treebank/configs/cnn_glove_small.cfg
+++ b/benchmarks/parsing_penn_treebank/configs/cnn_glove_small.cfg
@@ -38,7 +38,7 @@ use_upper = true
 nO = null
 
 [components.parser.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.parser.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/benchmarks/textcat_architectures/configs/config_cmu_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_cmu_ensemble.cfg
@@ -49,7 +49,7 @@ attrs = ["ORTH","LOWER","PREFIX","SUFFIX","SHAPE","ID"]
 include_static_vectors = false
 
 [components.textcat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = ${components.textcat.model.tok2vec.embed.width}
 window_size = 1
 maxout_pieces = 3

--- a/benchmarks/textcat_architectures/configs/config_cmu_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_cmu_ensemble.cfg
@@ -39,7 +39,7 @@ no_output_layer = false
 nO = null
 
 [components.textcat.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.textcat.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/benchmarks/textcat_architectures/configs/config_dbpedia_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_dbpedia_ensemble.cfg
@@ -49,7 +49,7 @@ attrs = ["ORTH","LOWER","PREFIX","SUFFIX","SHAPE","ID"]
 include_static_vectors = false
 
 [components.textcat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = ${components.textcat.model.tok2vec.embed.width}
 window_size = 1
 maxout_pieces = 3

--- a/benchmarks/textcat_architectures/configs/config_dbpedia_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_dbpedia_ensemble.cfg
@@ -39,7 +39,7 @@ no_output_layer = false
 nO = null
 
 [components.textcat.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.textcat.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/benchmarks/textcat_architectures/configs/config_imdb_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_imdb_ensemble.cfg
@@ -49,7 +49,7 @@ attrs = ["ORTH","LOWER","PREFIX","SUFFIX","SHAPE","ID"]
 include_static_vectors = false
 
 [components.textcat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = ${components.textcat.model.tok2vec.embed.width}
 window_size = 1
 maxout_pieces = 3

--- a/benchmarks/textcat_architectures/configs/config_imdb_ensemble.cfg
+++ b/benchmarks/textcat_architectures/configs/config_imdb_ensemble.cfg
@@ -39,7 +39,7 @@ no_output_layer = false
 nO = null
 
 [components.textcat.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.textcat.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/experimental/ner_spancat/configs/spancat.cfg
+++ b/experimental/ner_spancat/configs/spancat.cfg
@@ -39,7 +39,7 @@ nO = null
 nI = null
 
 [components.spancat.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.spancat.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/experimental/ner_spancat/configs/spancat.cfg
+++ b/experimental/ner_spancat/configs/spancat.cfg
@@ -49,7 +49,7 @@ attrs = ["ORTH","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.spancat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 window_size = 1
 maxout_pieces = 3

--- a/integrations/huggingface_hub/configs/config.cfg
+++ b/integrations/huggingface_hub/configs/config.cfg
@@ -44,7 +44,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/integrations/huggingface_hub/configs/config.cfg
+++ b/integrations/huggingface_hub/configs/config.cfg
@@ -54,7 +54,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/integrations/prodigy/configs/config.cfg
+++ b/integrations/prodigy/configs/config.cfg
@@ -44,7 +44,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/integrations/prodigy/configs/config.cfg
+++ b/integrations/prodigy/configs/config.cfg
@@ -54,7 +54,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/integrations/ray/configs/default.cfg
+++ b/integrations/ray/configs/default.cfg
@@ -58,7 +58,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/integrations/ray/configs/default.cfg
+++ b/integrations/ray/configs/default.cfg
@@ -68,7 +68,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/integrations/wandb/configs/default_config.cfg
+++ b/integrations/wandb/configs/default_config.cfg
@@ -45,7 +45,7 @@ nO = null
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/integrations/wandb/configs/default_config.cfg
+++ b/integrations/wandb/configs/default_config.cfg
@@ -55,7 +55,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/pipelines/ner_wikiner/configs/default.cfg
+++ b/pipelines/ner_wikiner/configs/default.cfg
@@ -44,7 +44,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/pipelines/ner_wikiner/configs/default.cfg
+++ b/pipelines/ner_wikiner/configs/default.cfg
@@ -54,7 +54,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/pipelines/tagger_parser_ud/configs/default.cfg
+++ b/pipelines/tagger_parser_ud/configs/default.cfg
@@ -79,7 +79,7 @@ rows = [5000,2500,2500,2500]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/pipelines/tagger_parser_ud/configs/default.cfg
+++ b/pipelines/tagger_parser_ud/configs/default.cfg
@@ -69,7 +69,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/tutorials/ner_drugs/configs/config.cfg
+++ b/tutorials/ner_drugs/configs/config.cfg
@@ -44,7 +44,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/tutorials/ner_drugs/configs/config.cfg
+++ b/tutorials/ner_drugs/configs/config.cfg
@@ -54,7 +54,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/tutorials/ner_fashion_brands/configs/config.cfg
+++ b/tutorials/ner_fashion_brands/configs/config.cfg
@@ -44,7 +44,7 @@ upstream = "*"
 factory = "tok2vec"
 
 [components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
 @architectures = "spacy.MultiHashEmbed.v1"

--- a/tutorials/ner_fashion_brands/configs/config.cfg
+++ b/tutorials/ner_fashion_brands/configs/config.cfg
@@ -54,7 +54,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/tutorials/textcat_goemotions/README.md
+++ b/tutorials/textcat_goemotions/README.md
@@ -71,7 +71,7 @@ custom config). For instance, you could edit the
 
 ```ini
 [components.textcat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 32
 depth = 4
 window_size = 1

--- a/tutorials/textcat_goemotions/configs/cnn.cfg
+++ b/tutorials/textcat_goemotions/configs/cnn.cfg
@@ -41,7 +41,7 @@ attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
 include_static_vectors = false
 
 [components.textcat.model.tok2vec.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
+@architectures = "spacy.MaxoutWindowEncoder.v2"
 width = 96
 depth = 4
 window_size = 1

--- a/tutorials/textcat_goemotions/configs/cnn.cfg
+++ b/tutorials/textcat_goemotions/configs/cnn.cfg
@@ -31,7 +31,7 @@ exclusive_classes = false
 nO = null
 
 [components.textcat.model.tok2vec]
-@architectures = "spacy.Tok2Vec.v1"
+@architectures = "spacy.Tok2Vec.v2"
 
 [components.textcat.model.tok2vec.embed]
 @architectures = "spacy.MultiHashEmbed.v1"


### PR DESCRIPTION
Not tested, though I don't think this should break anything.

We may want to do this for some other old architectures too, but for now
I just focused on this one.

Inspired by https://github.com/explosion/spaCy/discussions/9815.