### PR TITLE
Add floret Wikipedia+OSCAR vectors project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,8 @@ jobs:
                 pip install "spacy_lookups_data>=1.0.2,<1.1.0"
                 pip install torch==1.7.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
                 # for pipelines/floret_wiki_oscar_vectors
-                pip install floret more-itertools datasets wikiextractor
+                pip install floret more-itertools datasets
+                pip install "wikiextractor @ git+https://github.com/adrianeboyd/wikiextractor.git@v3.0.7a0"
             displayName: 'Install dependencies'
 
           - script: python -m pytest -s benchmarks experimental integrations pipelines tutorials

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,12 +31,14 @@ jobs:
                 architecture: 'x64'
 
           - script: |
-                pip install "spacy>=3.1.0,<3.2.0"
+                pip install "spacy>=3.2.0,<3.3.0"
                 pip install pytest
                 pip install wheel
                 pip install "numpy<1.20.0"
                 pip install "spacy_lookups_data>=1.0.2,<1.1.0"
                 pip install torch==1.7.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+                # for pipelines/floret_wiki_oscar_vectors
+                pip install floret more-itertools datasets wikiextractor
             displayName: 'Install dependencies'
 
           - script: python -m pytest -s benchmarks experimental integrations pipelines tutorials

--- a/pipelines/floret_wiki_oscar_vectors/README.md
+++ b/pipelines/floret_wiki_oscar_vectors/README.md
@@ -8,15 +8,12 @@ OSCAR and trains vectors with [floret](https://github.com/explosion/floret).
 By default, the project trains floret vectors for Macedonian.
 
 Prerequisites:
-- linux (you can try using `wikiextractor` with `fork` in OS X, but it's not
-  recommended)
 - a large amount of hard drive space
 - a workstation with a good CPU, or a lot of patience
 
 For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
 
-Adjust the variables `n_process_tokenize`, `n_process_wikiextractor` and
-`vector_thread` for your CPU.
+Adjust the variables `n_process` and `vector_thread` for your CPU.
 
 ## Text Sources
 

--- a/pipelines/floret_wiki_oscar_vectors/README.md
+++ b/pipelines/floret_wiki_oscar_vectors/README.md
@@ -8,12 +8,15 @@ OSCAR and trains vectors with [floret](https://github.com/explosion/floret).
 By default, the project trains floret vectors for Macedonian.
 
 Prerequisites:
+- linux (you can try using `wikiextractor` with `fork` in OS X, but it's not
+  recommended)
 - a large amount of hard drive space
 - a workstation with a good CPU, or a lot of patience
 
 For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
 
-Adjust the variables `n_process_tokenize` and `vector_thread` for your CPU.
+Adjust the variables `n_process_tokenize`, `n_process_wikiextractor` and
+`vector_thread` for your CPU.
 
 ## Text Sources
 

--- a/pipelines/floret_wiki_oscar_vectors/README.md
+++ b/pipelines/floret_wiki_oscar_vectors/README.md
@@ -22,7 +22,16 @@ Adjust the variables `n_process` and `vector_thread` for your CPU.
 
 By default the full OSCAR 2019 dataset is loaded in streaming mode. Adjust
 `oscar_max_texts` to use a subset of the full dataset, especially for large
-languages like English, Spanish, Chinese, Russian, etc.
+languages like English, Spanish, Chinese, Russian, etc. The text lengths are
+not consistent, but 1M texts may be ~3-5GB.
+
+## wikiextractor
+
+In order to fix a few bugs and support multiprocessing with spawn, this
+project installs a fork of [`wikiextractor`
+v3.0.6](https://github.com/attardi/wikiextractor) as wikiextractor v3.0.7a0.
+The modifications to wikiextractor v3.0.6 are described in [this
+commit](https://github.com/adrianeboyd/wikiextractor/commit/f8b539d46cd67205884d701c1d5fd18eda84825f).
 
 ## floret Parameters
 

--- a/pipelines/floret_wiki_oscar_vectors/README.md
+++ b/pipelines/floret_wiki_oscar_vectors/README.md
@@ -1,0 +1,153 @@
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS START (do not remove) -->
+
+# 🪐 spaCy Project: Train floret vectors from Wikipedia and OSCAR
+
+This project downloads, extracts and preprocesses texts from Wikipedia and
+OSCAR and trains vectors with [floret](https://github.com/explosion/floret).
+
+By default, the project trains floret vectors for Macedonian.
+
+Prerequisites:
+- a large amount of hard drive space
+- a workstation with a good CPU, or a lot of patience
+
+For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
+
+Adjust the variables `n_process_tokenize` and `vector_thread` for your CPU.
+
+## Text Sources
+
+- Wikipedia: https://dumps.wikimedia.org
+- OSCAR 2019: https://oscar-corpus.com/post/oscar-2019/
+
+By default the full OSCAR 2019 dataset is loaded in streaming mode. Adjust
+`oscar_max_texts` to use a subset of the full dataset, especially for large
+languages like English, Spanish, Chinese, Russian, etc.
+
+## floret Parameters
+
+[floret](https://github.com/explosion/floret) has a large number of
+parameters and it's difficult to give advice for all configurations, but the
+parameters described here are the ones that it makes sense to customize for
+any new language and to experiment with initially.
+
+Be aware that if you're using more than one thread, the results of each run
+with fastText or floret will be slightly different.
+
+### `vector_minn` / `vector_maxn`
+
+The minimum and maximum character n-gram lengths should be adapted for the
+language and writing system. The n-grams should capture common grammatical
+affixes like English `-ing`, without making the number of n-grams per word
+too large. Very short n-grams aren't meaningful and very long n-grams will be
+too sparse and won't be useful for cases with misspellings and noise.
+
+A good rule of thumb is that `maxn` should correspond to the length of the
+longest common affix + `1`, so for many languages with alphabets, `minn
+5`/`maxn 5` can be a good starting point, similar to the defaults in the
+[original fastText vectors](https://fasttext.cc/docs/en/crawl-vectors.html).
+
+For writing systems where one character corresponds to a syllable, shorter
+n-grams are typically more suitable. For Korean, where each (normalized)
+character is a syllable and most grammatical affixes are 1-2 characters,
+`minn 2`/`maxn 3` seems to perform well.
+
+### `vector_bucket`
+
+The bucket size is the number of rows in the floret vector table. For
+tagging and parsing, a bucket size of 50k performs well, but larger sizes may
+still lead to small improvements. For NER, the performance continues to
+improve for bucket sizes up to at least 200k.
+
+In a spaCy pipeline package, 50k 300-dim vectors are ~60MB and 200k 300-dim
+vectors are ~230MB.
+
+### `vector_hash_count`
+
+The recommended hash count is `2`, especially for smaller bucket sizes.
+
+Larger hash counts are slower to train with floret and slightly slower in
+inference in spaCy, but may lead to slightly improved performance, especially
+with larger bucket sizes.
+
+### `vector_epoch`
+
+You may want to reduce the number of epochs for larger training input sizes.
+
+### `vector_min_count`
+
+You may want to increase the minimum word count for larger training input
+sizes.
+
+### `vector_lr`
+
+You may need to decrease the learning rate for larger training input sizes to
+avoid NaN errors, see:
+https://fasttext.cc/docs/en/faqs.html#im-encountering-a-nan-why-could-this-be
+
+### `vector_thread`
+
+Adjust the number of threads for your CPU. With a larger number of threads,
+you may need more epochs to reach the same performance.
+
+## Notes
+
+The project does not currently clean up any intermediate files so that it's
+possible to resume from any point in the workflow. The overall disk space
+could be reduced by cleaning up files after each step, keeping only the final
+floret input text file. floret does require the input file to be on disk
+during training.
+
+floret always writes the full `.bin` and `.vec` files after training. These
+may be 5GB+ each even though the final `.floret` table is much smaller.
+
+Import the floret vectors into a spaCy vectors model with:
+
+```shell
+spacy init vectors mk vectors/mk.floret /path/to/mk_vectors_model --mode floret
+```
+
+
+## 📋 project.yml
+
+The [`project.yml`](project.yml) defines the data assets required by the
+project, as well as the available commands and workflows. For details, see the
+[spaCy projects documentation](https://spacy.io/usage/projects).
+
+### ⏯ Commands
+
+The following commands are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run).
+Commands are only re-run if their inputs have changed.
+
+| Command | Description |
+| --- | --- |
+| `extract-wikipedia` | Convert Wikipedia XML to JSONL with wikiextractor |
+| `tokenize-wikipedia` | Tokenize and sentencize Wikipedia |
+| `tokenize-oscar` | Tokenize and sentencize OSCAR dataset |
+| `create-input` | Concatenate tokenized input texts |
+| `train-floret-vectors` | Train floret vectors |
+| `train-fasttext-vectors` | Train fastText vectors |
+
+### ⏭ Workflows
+
+The following workflows are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run)
+and will run the specified commands in order. Commands are only re-run if their
+inputs have changed.
+
+| Workflow | Steps |
+| --- | --- |
+| `all` | `extract-wikipedia` &rarr; `tokenize-wikipedia` &rarr; `tokenize-oscar` &rarr; `create-input` &rarr; `train-floret-vectors` |
+
+### 🗂 Assets
+
+The following assets are defined by the project. They can
+be fetched by running [`spacy project assets`](https://spacy.io/api/cli#project-assets)
+in the project directory.
+
+| File | Source | Description |
+| --- | --- | --- |
+| `/scratch/vectors/downloaded/wikipedia/mkwiki-latest-pages-articles.xml.bz2` | URL |  |
+
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -265,6 +265,7 @@ commands:
         --epoch ${vars.vector_epoch}
         --thread ${vars.vector_thread}
         --lr ${vars.vector_lr}
+        --bucket 2000000
         ${vars.vector_input_dir}/${vars.lang}.txt
         vectors/${vars.lang}.fasttext
     deps:

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -6,12 +6,15 @@ description: |
   By default, the project trains floret vectors for Macedonian.
 
   Prerequisites:
+  - linux (you can try using `wikiextractor` with `fork` in OS X, but it's not
+    recommended)
   - a large amount of hard drive space
   - a workstation with a good CPU, or a lot of patience
 
   For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
 
-  Adjust the variables `n_process_tokenize` and `vector_thread` for your CPU.
+  Adjust the variables `n_process_tokenize`, `n_process_wikiextractor` and
+  `vector_thread` for your CPU.
 
   ## Text Sources
 
@@ -110,6 +113,8 @@ vars:
   name: "vectors"
   lang: "mk"
   n_process_tokenize: 16
+  # Set to 1 for windows
+  n_process_wikiextractor: 16
   # The defaults assume that you have a large hard drive mounted under /scratch
   downloaded_dir: "/scratch/vectors/downloaded"
   extracted_dir: "/scratch/vectors/extracted"
@@ -157,6 +162,7 @@ commands:
       - >-
         python -m wikiextractor.WikiExtractor
         --json --no-templates -b 1000G -q
+        --processes ${vars.n_process_wikiextractor}
         ${vars.downloaded_dir}/wikipedia/${vars.lang}wiki-${vars.wikipedia_version}-pages-articles.xml.bz2
         -o ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/
     outputs:

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -168,8 +168,8 @@ commands:
     script:
       - >-
         python scripts/tokenize_resource.py ${vars.lang}
+        ${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt
         --input-jsonl ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00
-        --output-file ${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt
         --n-process ${vars.n_process}
     deps:
       - "scripts/tokenize_resource.py"
@@ -182,10 +182,10 @@ commands:
     script:
       - >-
         python scripts/tokenize_resource.py ${vars.lang}
+        ${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt
         --input-dataset ${vars.oscar_dataset}
         --dataset-subset ${vars.oscar_dataset_subset}
         --dataset-split ${vars.oscar_dataset_split}
-        --output-file ${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt
         --n-process=${vars.n_process}
         --max-texts=${vars.oscar_max_texts}
     deps:

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -1,0 +1,254 @@
+title: "Train floret vectors from Wikipedia and OSCAR"
+description: |
+  This project downloads, extracts and preprocesses texts from Wikipedia and
+  OSCAR and trains vectors with [floret](https://github.com/explosion/floret).
+
+  By default, the project trains floret vectors for Macedonian.
+
+  Prerequisites:
+  - a large amount of hard drive space
+  - a workstation with a good CPU, or a lot of patience
+
+  For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
+
+  Adjust the variables `n_process_tokenize` and `vector_thread` for your CPU.
+
+  ## Text Sources
+
+  - Wikipedia: https://dumps.wikimedia.org
+  - OSCAR 2019: https://oscar-corpus.com/post/oscar-2019/
+
+  By default the full OSCAR 2019 dataset is loaded in streaming mode. Adjust
+  `oscar_max_texts` to use a subset of the full dataset, especially for large
+  languages like English, Spanish, Chinese, Russian, etc.
+
+  ## floret Parameters
+
+  [floret](https://github.com/explosion/floret) has a large number of
+  parameters and it's difficult to give advice for all configurations, but the
+  parameters described here are the ones that it makes sense to customize for
+  any new language and to experiment with initially.
+
+  Be aware that if you're using more than one thread, the results of each run
+  with fastText or floret will be slightly different.
+
+  ### `vector_minn` / `vector_maxn`
+  
+  The minimum and maximum character n-gram lengths should be adapted for the
+  language and writing system. The n-grams should capture common grammatical
+  affixes like English `-ing`, without making the number of n-grams per word
+  too large. Very short n-grams aren't meaningful and very long n-grams will be
+  too sparse and won't be useful for cases with misspellings and noise.
+
+  A good rule of thumb is that `maxn` should correspond to the length of the
+  longest common affix + `1`, so for many languages with alphabets, `minn
+  5`/`maxn 5` can be a good starting point, similar to the defaults in the
+  [original fastText vectors](https://fasttext.cc/docs/en/crawl-vectors.html).
+  
+  For writing systems where one character corresponds to a syllable, shorter
+  n-grams are typically more suitable. For Korean, where each (normalized)
+  character is a syllable and most grammatical affixes are 1-2 characters,
+  `minn 2`/`maxn 3` seems to perform well.
+
+  ### `vector_bucket`
+
+  The bucket size is the number of rows in the floret vector table. For
+  tagging and parsing, a bucket size of 50k performs well, but larger sizes may
+  still lead to small improvements. For NER, the performance continues to
+  improve for bucket sizes up to at least 200k.
+
+  In a spaCy pipeline package, 50k 300-dim vectors are ~60MB and 200k 300-dim
+  vectors are ~230MB.
+
+  ### `vector_hash_count`
+
+  The recommended hash count is `2`, especially for smaller bucket sizes.
+  
+  Larger hash counts are slower to train with floret and slightly slower in
+  inference in spaCy, but may lead to slightly improved performance, especially
+  with larger bucket sizes.
+
+  ### `vector_epoch`
+
+  You may want to reduce the number of epochs for larger training input sizes.
+
+  ### `vector_min_count`
+
+  You may want to increase the minimum word count for larger training input
+  sizes.
+
+  ### `vector_lr`
+
+  You may need to decrease the learning rate for larger training input sizes to
+  avoid NaN errors, see:
+  https://fasttext.cc/docs/en/faqs.html#im-encountering-a-nan-why-could-this-be
+
+  ### `vector_thread`
+  
+  Adjust the number of threads for your CPU. With a larger number of threads,
+  you may need more epochs to reach the same performance.
+
+  ## Notes
+
+  The project does not currently clean up any intermediate files so that it's
+  possible to resume from any point in the workflow. The overall disk space
+  could be reduced by cleaning up files after each step, keeping only the final
+  floret input text file. floret does require the input file to be on disk
+  during training.
+
+  floret always writes the full `.bin` and `.vec` files after training. These
+  may be 5GB+ each even though the final `.floret` table is much smaller.
+
+  Import the floret vectors into a spaCy vectors model with:
+
+  ```shell
+  spacy init vectors mk vectors/mk.floret /path/to/mk_vectors_model --mode floret
+  ```
+
+spacy_version: ">=3.2.0,<4.0.0"
+vars:
+  name: "vectors"
+  lang: "mk"
+  n_process_tokenize: 16
+  # The defaults assume that you have a large hard drive mounted under /scratch
+  downloaded_dir: "/scratch/vectors/downloaded"
+  extracted_dir: "/scratch/vectors/extracted"
+  tokenized_dir: "/scratch/vectors/tokenized"
+  wikipedia_version: "latest"
+  oscar_dataset: "oscar"
+  oscar_dataset_subset: "unshuffled_deduplicated_${vars.lang}"
+  oscar_dataset_split: "train"
+  # Limit for large languages like English, Spanish, Chinese, Russian
+  # Check the size of the raw corpus (under the column "Size deduplicated"):
+  # https://oscar-corpus.com/post/oscar-2019/
+  oscar_max_texts: -1
+  vector_input_dir: "/scratch/vectors/input"
+  vector_model: "cbow"
+  # For languages with alphabets: minn/maxn 4/5 or 5/5 is a good starting point.
+  vector_minn: 5
+  vector_maxn: 5
+  vector_epoch: 5
+  vector_dim: 300
+  vector_neg: 10
+  vector_bucket: 50000
+  vector_min_count: 20
+  vector_hash_count: 2
+  vector_thread: 16
+  vector_lr: 0.05
+
+directories: ["vectors"]
+
+assets:
+  - dest: "${vars.downloaded_dir}/wikipedia/${vars.lang}wiki-${vars.wikipedia_version}-pages-articles.xml.bz2"
+    url: "https://dumps.wikimedia.org/${vars.lang}wiki/${vars.wikipedia_version}/${vars.lang}wiki-${vars.wikipedia_version}-pages-articles.xml.bz2"
+
+workflows:
+  all:
+    - extract-wikipedia
+    - tokenize-wikipedia
+    - tokenize-oscar
+    - create-input
+    - train-floret-vectors
+
+commands:
+  - name: "extract-wikipedia"
+    help: "Convert Wikipedia XML to JSONL with wikiextractor"
+    script:
+      - >-
+        python -m wikiextractor.WikiExtractor
+        --json --no-templates -b 1000G -q
+        ${vars.downloaded_dir}/wikipedia/${vars.lang}wiki-${vars.wikipedia_version}-pages-articles.xml.bz2
+        -o ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/
+    outputs:
+      - "${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00"
+
+  - name: "tokenize-wikipedia"
+    help: "Tokenize and sentencize Wikipedia"
+    script:
+      - >-
+        python scripts/tokenize_resource.py ${vars.lang}
+        --input-jsonl ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00
+        --output-file ${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt
+        --n-process ${vars.n_process_tokenize}
+    deps:
+      - "scripts/tokenize_resource.py"
+      - "${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00"
+    outputs:
+      - "${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt"
+
+  - name: "tokenize-oscar"
+    help: "Tokenize and sentencize OSCAR dataset"
+    script:
+      - >-
+        python scripts/tokenize_resource.py ${vars.lang}
+        --input-dataset ${vars.oscar_dataset}
+        --dataset-subset ${vars.oscar_dataset_subset}
+        --dataset-split ${vars.oscar_dataset_split}
+        --output-file ${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt
+        --n-process=${vars.n_process_tokenize}
+        --max-texts=${vars.oscar_max_texts}
+    deps:
+      - "scripts/tokenize_resource.py"
+    outputs:
+      - "${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt"
+
+  - name: "create-input"
+    help: "Concatenate tokenized input texts"
+    script:
+      - >-
+        python scripts/concat_files.py 
+        --input-file ${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt
+        --input-file ${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt
+        ${vars.vector_input_dir}/${vars.lang}.txt
+    deps:
+      - "scripts/concat_files.py"
+      - "${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt"
+      - "${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt"
+    outputs:
+      - "${vars.vector_input_dir}/${vars.lang}.txt"
+
+  - name: "train-floret-vectors"
+    help: "Train floret vectors"
+    script:
+      - >-
+        python scripts/train_floret.py
+        --mode floret
+        --model ${vars.vector_model}
+        --dim ${vars.vector_dim}
+        --mincount ${vars.vector_min_count}
+        --minn ${vars.vector_minn}
+        --maxn ${vars.vector_maxn}
+        --neg ${vars.vector_neg}
+        --epoch ${vars.vector_epoch}
+        --hashcount ${vars.vector_hash_count}
+        --bucket ${vars.vector_bucket}
+        --thread ${vars.vector_thread}
+        ${vars.vector_input_dir}/${vars.lang}.txt
+        vectors/${vars.lang}
+    deps:
+      - "scripts/train_floret.py"
+      - "${vars.vector_input_dir}/${vars.lang}.txt"
+    outputs:
+      - "vectors/${vars.lang}.floret"
+
+  - name: "train-fasttext-vectors"
+    help: "Train fastText vectors"
+    script:
+      - >-
+        python scripts/train_floret.py
+        --mode fasttext
+        --model ${vars.vector_model}
+        --dim ${vars.vector_dim}
+        --mincount ${vars.vector_min_count}
+        --minn ${vars.vector_minn}
+        --maxn ${vars.vector_maxn}
+        --neg ${vars.vector_neg}
+        --epoch ${vars.vector_epoch}
+        --thread ${vars.vector_thread}
+        ${vars.vector_input_dir}/${vars.lang}.txt
+        vectors/${vars.lang}.fasttext
+    deps:
+      - "scripts/train_floret.py"
+      - "${vars.vector_input_dir}/${vars.lang}.txt"
+    outputs:
+      - "vectors/${vars.lang}.fasttext.vec"

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -224,6 +224,7 @@ commands:
         --hashcount ${vars.vector_hash_count}
         --bucket ${vars.vector_bucket}
         --thread ${vars.vector_thread}
+        --lr ${vars.vector_lr}
         ${vars.vector_input_dir}/${vars.lang}.txt
         vectors/${vars.lang}
     deps:
@@ -246,6 +247,7 @@ commands:
         --neg ${vars.vector_neg}
         --epoch ${vars.vector_epoch}
         --thread ${vars.vector_thread}
+        --lr ${vars.vector_lr}
         ${vars.vector_input_dir}/${vars.lang}.txt
         vectors/${vars.lang}.fasttext
     deps:

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -6,8 +6,6 @@ description: |
   By default, the project trains floret vectors for Macedonian.
 
   Prerequisites:
-  - linux (you can try using `wikiextractor` with `fork` in OS X, but it's not
-    recommended)
   - a large amount of hard drive space
   - a workstation with a good CPU, or a lot of patience
 
@@ -113,7 +111,6 @@ vars:
   name: "vectors"
   lang: "mk"
   n_process_tokenize: 16
-  # Set to 1 for windows
   n_process_wikiextractor: 16
   # The defaults assume that you have a large hard drive mounted under /scratch
   downloaded_dir: "/scratch/vectors/downloaded"

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -11,8 +11,7 @@ description: |
 
   For Macedonian, you'll need ~5GB in `/scratch` and ~1GB in `vectors/`.
 
-  Adjust the variables `n_process_tokenize`, `n_process_wikiextractor` and
-  `vector_thread` for your CPU.
+  Adjust the variables `n_process` and `vector_thread` for your CPU.
 
   ## Text Sources
 
@@ -110,8 +109,7 @@ spacy_version: ">=3.2.0,<4.0.0"
 vars:
   name: "vectors"
   lang: "mk"
-  n_process_tokenize: 16
-  n_process_wikiextractor: 16
+  n_process: 16
   # The defaults assume that you have a large hard drive mounted under /scratch
   downloaded_dir: "/scratch/vectors/downloaded"
   extracted_dir: "/scratch/vectors/extracted"
@@ -159,7 +157,7 @@ commands:
       - >-
         python -m wikiextractor.WikiExtractor
         --json --no-templates -b 1000G -q
-        --processes ${vars.n_process_wikiextractor}
+        --processes ${vars.n_process}
         ${vars.downloaded_dir}/wikipedia/${vars.lang}wiki-${vars.wikipedia_version}-pages-articles.xml.bz2
         -o ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/
     outputs:
@@ -172,7 +170,7 @@ commands:
         python scripts/tokenize_resource.py ${vars.lang}
         --input-jsonl ${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00
         --output-file ${vars.tokenized_dir}/${vars.lang}_wiki_${vars.wikipedia_version}.txt
-        --n-process ${vars.n_process_tokenize}
+        --n-process ${vars.n_process}
     deps:
       - "scripts/tokenize_resource.py"
       - "${vars.extracted_dir}/${vars.lang}_wiki_${vars.wikipedia_version}/AA/wiki_00"
@@ -188,7 +186,7 @@ commands:
         --dataset-subset ${vars.oscar_dataset_subset}
         --dataset-split ${vars.oscar_dataset_split}
         --output-file ${vars.tokenized_dir}/${vars.lang}_oscar_${vars.oscar_dataset_subset}.txt
-        --n-process=${vars.n_process_tokenize}
+        --n-process=${vars.n_process}
         --max-texts=${vars.oscar_max_texts}
     deps:
       - "scripts/tokenize_resource.py"

--- a/pipelines/floret_wiki_oscar_vectors/project.yml
+++ b/pipelines/floret_wiki_oscar_vectors/project.yml
@@ -20,7 +20,16 @@ description: |
 
   By default the full OSCAR 2019 dataset is loaded in streaming mode. Adjust
   `oscar_max_texts` to use a subset of the full dataset, especially for large
-  languages like English, Spanish, Chinese, Russian, etc.
+  languages like English, Spanish, Chinese, Russian, etc. The text lengths are
+  not consistent, but 1M texts may be ~3-5GB.
+
+  ## wikiextractor
+
+  In order to fix a few bugs and support multiprocessing with spawn, this
+  project installs a fork of [`wikiextractor`
+  v3.0.6](https://github.com/attardi/wikiextractor) as wikiextractor v3.0.7a0.
+  The modifications to wikiextractor v3.0.6 are described in [this
+  commit](https://github.com/adrianeboyd/wikiextractor/commit/f8b539d46cd67205884d701c1d5fd18eda84825f).
 
   ## floret Parameters
 

--- a/pipelines/floret_wiki_oscar_vectors/requirements.txt
+++ b/pipelines/floret_wiki_oscar_vectors/requirements.txt
@@ -1,0 +1,6 @@
+floret>=0.10.2
+wikiextractor>=3.0.6
+# Tested with v8.8.0, earlier versions may also work
+more-itertools>=8.8.0
+# Tested with v1.18.3, earlier versions may also work
+datasets>=1.18.0

--- a/pipelines/floret_wiki_oscar_vectors/requirements.txt
+++ b/pipelines/floret_wiki_oscar_vectors/requirements.txt
@@ -1,6 +1,11 @@
 floret>=0.10.2
+
+# This is a patched version of wikiextractor v3.0.6 that supports spawn
+# for the options `--json --no-templates` and fixes a few small bugs.
 wikiextractor @ git+https://github.com/adrianeboyd/wikiextractor.git@v3.0.7a0
-# Tested with v8.8.0, earlier versions may also work
+
+# Tested with v8.8.0, earlier versions may also work.
 more-itertools>=8.8.0
-# Tested with v1.18.3, earlier versions may also work
+
+# Tested with v1.18.3, earlier versions may also work.
 datasets>=1.18.0

--- a/pipelines/floret_wiki_oscar_vectors/requirements.txt
+++ b/pipelines/floret_wiki_oscar_vectors/requirements.txt
@@ -1,5 +1,5 @@
 floret>=0.10.2
-wikiextractor>=3.0.6
+wikiextractor @ git+https://github.com/adrianeboyd/wikiextractor.git@v3.0.7a0
 # Tested with v8.8.0, earlier versions may also work
 more-itertools>=8.8.0
 # Tested with v1.18.3, earlier versions may also work

--- a/pipelines/floret_wiki_oscar_vectors/scripts/concat_files.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/concat_files.py
@@ -12,7 +12,7 @@ def main(
     with open(output_file, "wb") as output_fileh:
         for filename in input_file:
             with open(filename, "rb") as fileh:
-                shutil.copyfileobj(fileh, output_fileh)
+                shutil.copyfileobj(fileh, output_fileh, length=1000000)
 
 
 if __name__ == "__main__":

--- a/pipelines/floret_wiki_oscar_vectors/scripts/concat_files.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/concat_files.py
@@ -1,0 +1,19 @@
+from typing import Optional, List
+import typer
+import shutil
+from pathlib import Path
+
+
+def main(
+    output_file: Path,
+    input_file: Optional[List[Path]] = typer.Option(None),
+):
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "wb") as output_fileh:
+        for filename in input_file:
+            with open(filename, "rb") as fileh:
+                shutil.copyfileobj(fileh, output_fileh)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
@@ -1,0 +1,81 @@
+from typing import Optional
+import re
+import srsly
+import spacy
+import typer
+from itertools import islice
+from pathlib import Path
+from functools import partial
+from multiprocessing import Pool
+from datasets import load_dataset
+from more_itertools import chunked
+
+
+def tokenize_batch(nlp, batch):
+    output = []
+    texts = (re.sub(r"\s+", " ", line.strip()) for line in batch)
+    for doc in nlp.pipe(texts):
+        for sent in doc.sents:
+            output.append(" ".join([t.text for t in sent]) + "\n")
+    return output
+
+
+def main(
+    lang: str,
+    input_jsonl: Optional[Path] = None,
+    input_dataset: Optional[str] = None,
+    dataset_subset: Optional[str] = None,
+    dataset_split: Optional[str] = None,
+    dataset_streaming: bool = True,
+    dataset_auth_token: bool = False,
+    output_file: Optional[Path] = None,
+    max_texts: int = -1,
+    n_process: int = 8,
+    batch_size: int = 1000,
+):
+    if input_jsonl is None and input_dataset is None:
+        raise ValueError(
+            "Provide either an input JSONL file or an input huggingface dataset."
+        )
+
+    if lang == "ko":
+        nlp = spacy.blank(
+            "ko", config={"nlp": {"tokenizer": {"@tokenizers": "spacy.Tokenizer.v1"}}}
+        )
+    elif lang == "zh":
+        nlp = spacy.blank("zh", config={"nlp": {"tokenizer": {"segmenter": "pkuseg"}}})
+        nlp.tokenizer.initialize(pkuseg_model="spacy_ontonotes")
+    else:
+        try:
+            nlp = spacy.blank(lang)
+        except ImportError:
+            print(f"Using xx tokenizer since {lang} is not supported by spaCy")
+            nlp = spacy.blank("xx")
+
+    nlp.add_pipe("sentencizer")
+    nlp.max_length = 10**8
+
+    if input_jsonl:
+        dataset = srsly.read_jsonl(input_jsonl)
+    elif input_dataset:
+        dataset = load_dataset(
+            input_dataset,
+            dataset_subset,
+            split=dataset_split,
+            streaming=dataset_streaming,
+            use_auth_token=dataset_auth_token,
+        )
+    if max_texts > 0:
+        texts = (line["text"] for line in islice(iter(dataset), max_texts))
+    else:
+        texts = (line["text"] for line in dataset)
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w") as output_fileh, Pool(processes=n_process) as pool:
+        result = pool.imap(partial(tokenize_batch, nlp), chunked(texts, batch_size))
+        for lines in result:
+            output_fileh.writelines(lines)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
@@ -71,7 +71,9 @@ def main(
         texts = (line["text"] for line in dataset)
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_file, "w", encoding="utf-8") as output_fileh, Pool(processes=n_process) as pool:
+    with open(output_file, "w", encoding="utf-8") as output_fileh, Pool(
+        processes=n_process
+    ) as pool:
         result = pool.imap(partial(tokenize_batch, nlp), chunked(texts, batch_size))
         for lines in result:
             output_fileh.writelines(lines)

--- a/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
@@ -71,7 +71,7 @@ def main(
         texts = (line["text"] for line in dataset)
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_file, "w") as output_fileh, Pool(processes=n_process) as pool:
+    with open(output_file, "w", encoding="utf-8") as output_fileh, Pool(processes=n_process) as pool:
         result = pool.imap(partial(tokenize_batch, nlp), chunked(texts, batch_size))
         for lines in result:
             output_fileh.writelines(lines)

--- a/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/tokenize_resource.py
@@ -22,13 +22,13 @@ def tokenize_batch(nlp, batch):
 
 def main(
     lang: str,
+    output_file: Path,
     input_jsonl: Optional[Path] = None,
     input_dataset: Optional[str] = None,
     dataset_subset: Optional[str] = None,
     dataset_split: Optional[str] = None,
     dataset_streaming: bool = True,
     dataset_auth_token: bool = False,
-    output_file: Optional[Path] = None,
     max_texts: int = -1,
     n_process: int = 8,
     batch_size: int = 1000,

--- a/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
@@ -1,0 +1,42 @@
+import typer
+from pathlib import Path
+import floret
+
+
+def main(
+    input_file: Path,
+    output_stem: str,
+    mode: str = "floret",
+    model: str = "cbow",
+    dim: int = 300,
+    mincount: int = 10,
+    minn: int = 5,
+    maxn: int = 5,
+    neg: int = 10,
+    epoch: int = 5,
+    hashcount: int = 2,
+    bucket: int = 20000,
+    thread: int = 8,
+):
+    floret_model = floret.train_unsupervised(
+        str(input_file.absolute()),
+        model=model,
+        mode=mode,
+        dim=dim,
+        minCount=mincount,
+        minn=minn,
+        maxn=maxn,
+        neg=neg,
+        epoch=epoch,
+        hashCount=hashcount,
+        bucket=bucket,
+        thread=thread,
+    )
+    floret_model.save_model(output_stem + ".bin")
+    floret_model.save_vectors(output_stem + ".vec")
+    if mode == "floret":
+        floret_model.save_floret_vectors(output_stem + ".floret")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
@@ -17,6 +17,7 @@ def main(
     hashcount: int = 2,
     bucket: int = 20000,
     thread: int = 8,
+    lr: float = 0.05,
 ):
     floret_model = floret.train_unsupervised(
         str(input_file.absolute()),
@@ -31,6 +32,7 @@ def main(
         hashCount=hashcount,
         bucket=bucket,
         thread=thread,
+        lr=lr,
     )
     floret_model.save_model(output_stem + ".bin")
     floret_model.save_vectors(output_stem + ".vec")

--- a/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
+++ b/pipelines/floret_wiki_oscar_vectors/scripts/train_floret.py
@@ -15,7 +15,7 @@ def main(
     neg: int = 10,
     epoch: int = 5,
     hashcount: int = 2,
-    bucket: int = 20000,
+    bucket: int = 50000,
     thread: int = 8,
     lr: float = 0.05,
 ):

--- a/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
+++ b/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
@@ -5,7 +5,6 @@ from spacy.cli.project.assets import project_assets
 from pathlib import Path
 
 
-
 def test_floret_web_vectors():
     root = Path(__file__).parent
     overrides = {

--- a/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
+++ b/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
@@ -17,6 +17,8 @@ def test_floret_web_vectors():
         "vars.extracted_dir": "./temp",
         "vars.tokenized_dir": "./temp",
         "vars.vector_input_dir": "./temp",
+        "vars.vector_dim": 100,
+        "vars.vector_bucket": 100,
     }
     project_assets(root, overrides=overrides)
     project_run(root, "all", overrides=overrides, capture=True)

--- a/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
+++ b/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
@@ -1,0 +1,19 @@
+import pytest
+from spacy.cli.project.run import project_run
+from spacy.cli.project.assets import project_assets
+from pathlib import Path
+
+
+def test_floret_web_vectors():
+    root = Path(__file__).parent
+    overrides = {
+        "vars.lang": "yo",
+        "vars.n_process_tokenize": 2,
+        "vars.vector_thread": 2,
+        "vars.downloaded_dir": "./temp",
+        "vars.extracted_dir": "./temp",
+        "vars.tokenized_dir": "./temp",
+        "vars.vector_input_dir": "./temp",
+    }
+    project_assets(root, overrides=overrides)
+    project_run(root, "all", overrides=overrides, capture=True)

--- a/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
+++ b/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
@@ -5,9 +5,6 @@ from spacy.cli.project.assets import project_assets
 from pathlib import Path
 
 
-if not sys.platform.startswith("linux"):
-    pytest.skip("skipping tests for not-linux", allow_module_level=True)
-
 
 def test_floret_web_vectors():
     root = Path(__file__).parent

--- a/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
+++ b/pipelines/floret_wiki_oscar_vectors/test_floret_wiki_oscar_vectors.py
@@ -1,7 +1,12 @@
 import pytest
+import sys
 from spacy.cli.project.run import project_run
 from spacy.cli.project.assets import project_assets
 from pathlib import Path
+
+
+if not sys.platform.startswith("linux"):
+    pytest.skip("skipping tests for not-linux", allow_module_level=True)
 
 
 def test_floret_web_vectors():
@@ -9,6 +14,7 @@ def test_floret_web_vectors():
     overrides = {
         "vars.lang": "yo",
         "vars.n_process_tokenize": 2,
+        "vars.n_process_wikiextractor": 2,
         "vars.vector_thread": 2,
         "vars.downloaded_dir": "./temp",
         "vars.extracted_dir": "./temp",


### PR DESCRIPTION
Add a user-friendly cross-platform floret vectors project for training on Wikipedia (using `wikiextractor`) + OSCAR (using `datasets`).

The project defaults use Macedonian to provide a small but realistic demo.

The tests override the defaults to use the much-smaller Yoruba data sources.