### PR TITLE
Pin conllu version in speed benchmark

### DIFF
--- a/benchmarks/speed/requirements.txt
+++ b/benchmarks/speed/requirements.txt
@@ -1,5 +1,6 @@
 transformers>=3.4.0,<4.3.0
 spacy-transformers>=1.0.1,<1.1.0
 stanza>=1.3.0,<1.5.0
+conllu>=4.4,<4.4.3
 flair>=0.6.0,<1.0.0
 ufal.udpipe


### PR DESCRIPTION
Due to new version with backwards incompatibilities being released yesterday. The new version breaks `spacy run download` in the speed  benchmark, since the latest `flair` version doesn't consider this yet.