### PR TITLE
Extend speed benchmark requirements to avoid sklearn import exception

### DIFF
--- a/benchmarks/speed/requirements.txt
+++ b/benchmarks/speed/requirements.txt
@@ -1,5 +1,8 @@
 transformers>=3.4.0,<4.3.0
 spacy-transformers>=1.0.1,<1.1.0
+numpy>=1.19.0,<1.19.6
+scipy>=1.7.0,<1.7.4
+scikit-learn>=1.0.0,<1.0.3
 stanza>=1.3.0,<1.5.0
 flair>=0.6.0,<1.0.0
 ufal.udpipe

--- a/benchmarks/speed/requirements.txt
+++ b/benchmarks/speed/requirements.txt
@@ -1,8 +1,6 @@
+scipy>=1.7.0,<1.7.4
 transformers>=3.4.0,<4.3.0
 spacy-transformers>=1.0.1,<1.1.0
-numpy>=1.19.0,<1.19.6
-scipy>=1.7.0,<1.7.4
-scikit-learn>=1.0.0,<1.0.3
 stanza>=1.3.0,<1.5.0
 flair>=0.6.0,<1.0.0
 ufal.udpipe


### PR DESCRIPTION
## Goals

Fix the [`__check_build` import error for `scikit-learn` in the speed benchmark](https://buildkite.com/explosion-ai/spacy-projects/builds/24#01821079-7b9c-4a44-a5af-73cc758620b7/112-366). 

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Add `scipy` as explicit dependency. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
