### PR TITLE
Update speed benchmark

### DIFF
--- a/benchmarks/speed/project.yml
+++ b/benchmarks/speed/project.yml
@@ -26,7 +26,6 @@ directories: ["scripts", "texts", "results"]
 # haven't changed, it won't be re-run.
 workflows:
   setup:
-    - install
     - download
   benchmark:
     - timing_cpu
@@ -43,13 +42,6 @@ assets:
 # via "spacy project run [command] [path]". The help message is optional and
 # shown when executing "spacy project run [optional command] [path] --help".
 commands:
-  - name: install
-    help: "Install dependencies"
-    script:
-      - "python -m pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html"
-    deps:
-      - "requirements.txt"
-
   - name: download
     help: "Download models"
     script:

--- a/benchmarks/speed/project.yml
+++ b/benchmarks/speed/project.yml
@@ -26,6 +26,7 @@ directories: ["scripts", "texts", "results"]
 # haven't changed, it won't be re-run.
 workflows:
   setup:
+    - install
     - download
   benchmark:
     - timing_cpu
@@ -42,6 +43,13 @@ assets:
 # via "spacy project run [command] [path]". The help message is optional and
 # shown when executing "spacy project run [optional command] [path] --help".
 commands:
+  - name: install
+    help: "Install dependencies"
+    script:
+      - "python -m pip install -r requirements.txt"
+    deps:
+      - "requirements.txt"
+
   - name: download
     help: "Download models"
     script:

--- a/benchmarks/speed/requirements.txt
+++ b/benchmarks/speed/requirements.txt
@@ -1,5 +1,4 @@
-transformers>=3.4.0,<4.3.0
-spacy-transformers>=1.0.1,<1.1.0
+spacy-transformers>=1.0.5,<1.2.0
 stanza>=1.3.0,<1.5.0
 conllu>=4.4,<4.4.3
 flair>=0.6.0,<1.0.0

--- a/benchmarks/speed/scripts/run_nlp.py
+++ b/benchmarks/speed/scripts/run_nlp.py
@@ -87,12 +87,6 @@ def _run_spacy_model(name: str, gpu: bool) -> Callable[[List[str]], None]:
     if gpu:
         spacy.require_gpu(0)
     nlp = spacy.load(name)
-    # quick hack
-    if "trf" in name:
-        trf_model = nlp.get_pipe("transformer").model
-        max_length = trf_model.attrs["tokenizer"].model_max_length
-        config = {"min_length": max_length, "split_length": 2}
-        nlp.add_pipe("token_splitter", config=config, first=True)
 
     def run(texts: List[str], batch_size: int):
         list(nlp.pipe(texts, batch_size=batch_size))
@@ -169,7 +163,7 @@ def _run_flair_model(name: str, gpu: bool) -> Callable[[List[str]], None]:
         # re-batch, concatenating with \n\n
         for text in rebatch_texts(texts, batch_size):
             sentences = splitter.split(text)
-            tagger.predict(sentences, verbose=False)
+            tagger.predict(sentences)
 
     return run
 


### PR DESCRIPTION
Update speed benchmark for newer `spacy-transformers` and `flair` APIs.

Requires #119 for the tests to pass.