### PR TITLE
project to preprocess spancat datasets into .spacy

### DIFF
--- a/pipelines/spancat-datasets/README.md
+++ b/pipelines/spancat-datasets/README.md
@@ -1,0 +1,93 @@
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS START (do not remove) -->
+
+# 🪐 spaCy Project: Spancat datasets
+
+This project compiles various spancat datasets and their converters into the
+[spaCy format](https://spacy.io/api/data-formats). You can use this in tandem
+with the [`spancat-encoders`](https://github.com/explosion/spancat-encoders)
+repository to run various experiments on these datasets.
+
+
+## 📋 project.yml
+
+The [`project.yml`](project.yml) defines the data assets required by the
+project, as well as the available commands and workflows. For details, see the
+[spaCy projects documentation](https://spacy.io/usage/projects).
+
+### ⏯ Commands
+
+The following commands are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run).
+Commands are only re-run if their inputs have changed.
+
+| Command | Description |
+| --- | --- |
+| `convert-wnut17-ents` | Convert WNUT17 dataset into the spaCy format |
+| `convert-wnut17-spans` | Convert WNUT17 dataset into the spaCy format |
+| `clean-wikineural` | Remove unnecessary indices from wikineural data |
+| `convert-wikineural-spans` | Convert WikiNeural dataset (de, en, es, nl) into the spaCy format |
+| `convert-wikineural-ents` | Convert WikiNeural dataset (de, en, es, nl) into the spaCy format |
+| `clean-conll` | Remove unnecessary indices from ConLL data |
+| `convert-conll-spans` | Convert CoNLL dataset (de, en, es, nl) into the spaCy format |
+| `convert-conll-ents` | Convert CoNLL dataset (de, en, es, nl) into the spaCy format |
+| `convert-archaeo-spans` | Convert Dutch Archaeology dataset into the spaCy format |
+| `convert-archaeo-ents` | Convert Dutch Archaeology dataset into the spaCy format |
+| `convert-anem-spans` | Convert AnEM dataset into the spaCy format |
+| `convert-anem-ents` | Convert AnEM dataset into the spaCy format |
+| `clean` | Remove intermediary files |
+
+### ⏭ Workflows
+
+The following workflows are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run)
+and will run the specified commands in order. Commands are only re-run if their
+inputs have changed.
+
+| Workflow | Steps |
+| --- | --- |
+| `wnut17` | `convert-wnut17-ents` &rarr; `convert-wnut17-spans` |
+| `wikineural` | `clean-wikineural` &rarr; `convert-wikineural-ents` &rarr; `convert-wikineural-spans` |
+| `conll` | `clean-conll` &rarr; `convert-conll-spans` &rarr; `convert-conll-ents` |
+| `archaeo` | `convert-archaeo-ents` &rarr; `convert-archaeo-spans` |
+| `anem` | `convert-anem-ents` &rarr; `convert-anem-spans` |
+
+### 🗂 Assets
+
+The following assets are defined by the project. They can
+be fetched by running [`spacy project assets`](https://spacy.io/api/cli#project-assets)
+in the project directory.
+
+| File | Source | Description |
+| --- | --- | --- |
+| `assets/wnut17-train.iob` | URL | WNUT17 training dataset for Emerging and Rare Entities Task from Derczynski et al., 2017 |
+| `assets/wnut17-dev.iob` | URL | WNUT17 dev dataset for Emerging and Rare Entities Task from Derczynski et al., 2017 |
+| `assets/wnut17-test.iob` | URL | WNUT17 test dataset for Emerging and Rare Entities Task from Derczynski et al., 2017 |
+| `assets/raw-en-wikineural-train.iob` | URL | WikiNeural (en) training dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-en-wikineural-dev.iob` | URL | WikiNeural (en) dev dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-en-wikineural-test.iob` | URL | WikiNeural (en) test dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-de-wikineural-train.iob` | URL | WikiNeural (de) training dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-de-wikineural-dev.iob` | URL | WikiNeural (de) dev dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-de-wikineural-test.iob` | URL | WikiNeural (de) test dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-es-wikineural-train.iob` | URL | WikiNeural (es) training dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-es-wikineural-dev.iob` | URL | WikiNeural (es) dev dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-es-wikineural-test.iob` | URL | WikiNeural (es) test dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-nl-wikineural-train.iob` | URL | WikiNeural (nl) training dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-nl-wikineural-dev.iob` | URL | WikiNeural (nl) dev dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-nl-wikineural-test.iob` | URL | WikiNeural (nl) test dataset from Tedeschi et al. (EMNLP 2021) |
+| `assets/raw-en-conll-train.iob` | URL | CoNLL 2003 (en) training dataset |
+| `assets/raw-en-conll-dev.iob` | URL | CoNLL 2003 (en) dev dataset |
+| `assets/raw-en-conll-test.iob` | URL | CoNLL 2003 (en) test dataset |
+| `assets/raw-de-conll-train.iob` | URL | CoNLL 2003 (de) training dataset |
+| `assets/raw-de-conll-dev.iob` | URL | CoNLL 2003 (de) dev dataset |
+| `assets/raw-de-conll-test.iob` | URL | CoNLL 2003 (de) test dataset |
+| `assets/raw-es-conll-train.iob` | URL | CoNLL 2002 (es) training dataset |
+| `assets/raw-es-conll-dev.iob` | URL | CoNLL 2002 (es) dev dataset |
+| `assets/raw-es-conll-test.iob` | URL | CoNLL (es) test dataset |
+| `assets/raw-nl-conll-train.iob` | URL | CoNLL 2002 (nl) training dataset |
+| `assets/raw-nl-conll-dev.iob` | URL | CoNLL 2002 (nl) dev dataset |
+| `assets/raw-nl-conll-test.iob` | URL | CoNLL 202 (nl) test dataset |
+| `assets/archaeo.bio` | URL | Dutch Archaeological NER dataset by Alex Brandsen (LREC 2020) |
+| `assets/anem-train.iob` | URL | Anatomical Entity Mention (AnEM) training corpus containing abstracts and full-text biomedical papers from Ohta et al. (ACL 2012) |
+| `assets/anem-test.iob` | URL | Anatomical Entity Mention (AnEM) test corpus containing abstracts and full-text biomedical papers from Ohta et al. (ACL 2012) |
+
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/pipelines/spancat-datasets/project.yml
+++ b/pipelines/spancat-datasets/project.yml
@@ -1,0 +1,810 @@
+title: "Spancat datasets"
+description: |
+  This project compiles various spancat datasets and their converters into the
+  [spaCy format](https://spacy.io/api/data-formats). You can use this in tandem
+  with the [`spancat-encoders`](https://github.com/explosion/spancat-encoders)
+  repository to run various experiments on these datasets.
+
+vars:
+  spans_key: "sc"
+  gpu_id: 0
+
+directories:
+  - "assets"
+  - "configs"
+  - "corpus"
+  - "corpus/spancat"
+  - "corpus/ner"
+  - "scripts"
+
+workflows:
+  wnut17:
+    - "convert-wnut17-ents"
+    - "convert-wnut17-spans"
+    - "inspect-wnut17"
+  wikineural:
+    - "clean-wikineural"
+    - "convert-wikineural-ents"
+    - "convert-wikineural-spans"
+    - "inspect-wikineural"
+  conll:
+    - "clean-conll"
+    - "convert-conll-spans"
+    - "convert-conll-ents"
+    - "inspect-conll"
+  archaeo:
+    - "convert-archaeo-ents"
+    - "convert-archaeo-spans"
+    - "inspect-archaeo"
+  anem:
+    - "convert-anem-ents"
+    - "convert-anem-spans"
+  all:
+    - "convert-wnut17-ents"
+    - "convert-wnut17-spans"
+    - "clean-wikineural"
+    - "convert-wikineural-ents"
+    - "convert-wikineural-spans"
+    - "clean-conll"
+    - "convert-conll-spans"
+    - "convert-conll-ents"
+    - "convert-archaeo-ents"
+    - "convert-archaeo-spans"
+    - "convert-anem-ents"
+    - "convert-anem-spans"
+
+assets:
+  # WNUT17
+  - dest: "assets/wnut17-train.iob"
+    description: "WNUT17 training dataset for Emerging and Rare Entities Task from Derczynski et al., 2017"
+    url: https://github.com/juand-r/entity-recognition-datasets/blob/master/data/WNUT17/CONLL-format/data/train/wnut17train.conll
+  - dest: "assets/wnut17-dev.iob"
+    description: "WNUT17 dev dataset for Emerging and Rare Entities Task from Derczynski et al., 2017"
+    url: https://github.com/juand-r/entity-recognition-datasets/blob/master/data/WNUT17/CONLL-format/data/dev/emerging.dev.conll
+  - dest: "assets/wnut17-test.iob"
+    description: "WNUT17 test dataset for Emerging and Rare Entities Task from Derczynski et al., 2017"
+    url: https://github.com/juand-r/entity-recognition-datasets/blob/master/data/WNUT17/CONLL-format/data/test/emerging.test.annotated
+  ### Wikineural datasets ###
+  # Wikineural (en)
+  - dest: "assets/raw-en-wikineural-train.iob"
+    description: "WikiNeural (en) training dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/train.conllu
+  - dest: "assets/raw-en-wikineural-dev.iob"
+    description: "WikiNeural (en) dev dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/val.conllu
+  - dest: "assets/raw-en-wikineural-test.iob"
+    description: "WikiNeural (en) test dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/en/test.conllu
+  # Wikineural (de)
+  - dest: "assets/raw-de-wikineural-train.iob"
+    description: "WikiNeural (de) training dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/train.conllu
+  - dest: "assets/raw-de-wikineural-dev.iob"
+    description: "WikiNeural (de) dev dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/val.conllu
+  - dest: "assets/raw-de-wikineural-test.iob"
+    description: "WikiNeural (de) test dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/de/test.conllu
+  # Wikineural (es)
+  - dest: "assets/raw-es-wikineural-train.iob"
+    description: "WikiNeural (es) training dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/train.conllu
+  - dest: "assets/raw-es-wikineural-dev.iob"
+    description: "WikiNeural (es) dev dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/val.conllu
+  - dest: "assets/raw-es-wikineural-test.iob"
+    description: "WikiNeural (es) test dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/es/test.conllu
+  # Wikineural (nl)
+  - dest: "assets/raw-nl-wikineural-train.iob"
+    description: "WikiNeural (nl) training dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/train.conllu
+  - dest: "assets/raw-nl-wikineural-dev.iob"
+    description: "WikiNeural (nl) dev dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/val.conllu
+  - dest: "assets/raw-nl-wikineural-test.iob"
+    description: "WikiNeural (nl) test dataset from Tedeschi et al. (EMNLP 2021)"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/wikineural/nl/test.conllu
+  ### ConLL datasets ###
+  #  CoNLL-2003 (en)
+  - dest: "assets/raw-en-conll-train.iob"
+    description: "CoNLL 2003 (en) training dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/en/train.conllu
+  - dest: "assets/raw-en-conll-dev.iob"
+    description: "CoNLL 2003 (en) dev dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/en/val.conllu
+  - dest: "assets/raw-en-conll-test.iob"
+    description: "CoNLL 2003 (en) test dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/en/test.conllu
+  # CoNLL-2003 (de)
+  - dest: "assets/raw-de-conll-train.iob"
+    description: "CoNLL 2003 (de) training dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/de/train.conllu
+  - dest: "assets/raw-de-conll-dev.iob"
+    description: "CoNLL 2003 (de) dev dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/de/val.conllu
+  - dest: "assets/raw-de-conll-test.iob"
+    description: "CoNLL 2003 (de) test dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/de/test.conllu
+  # CoNLL-2002 (es)
+  - dest: "assets/raw-es-conll-train.iob"
+    description: "CoNLL 2002 (es) training dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/es/train.conllu
+  - dest: "assets/raw-es-conll-dev.iob"
+    description: "CoNLL 2002 (es) dev dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/es/val.conllu
+  - dest: "assets/raw-es-conll-test.iob"
+    description: "CoNLL (es) test dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/es/test.conllu
+  # CoNLL-2002 (nl)
+  - dest: "assets/raw-nl-conll-train.iob"
+    description: "CoNLL 2002 (nl) training dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/nl/train.conllu
+  - dest: "assets/raw-nl-conll-dev.iob"
+    description: "CoNLL 2002 (nl) dev dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/nl/val.conllu
+  - dest: "assets/raw-nl-conll-test.iob"
+    description: "CoNLL 202 (nl) test dataset"
+    url: https://github.com/Babelscape/wikineural/blob/master/data/conll/nl/test.conllu
+  ### Archaeo dataset ###
+  - dest: "assets/archaeo.bio"
+    description: "Dutch Archaeological NER dataset by Alex Brandsen (LREC 2020)"
+    url: https://github.com/alexbrandsen/dutch-archaeo-NER-dataset/blob/master/complete-bio-gs.bio
+  ### AnEM dataset ###
+  - dest: "assets/anem-train.iob"
+    description: "Anatomical Entity Mention (AnEM) training corpus containing abstracts and full-text biomedical papers from Ohta et al. (ACL 2012)"
+    url: https://github.com/juand-r/entity-recognition-datasets/blob/master/data/AnEM/CONLL-format/data/AnEM.train
+  - dest: "assets/anem-test.iob"
+    description: "Anatomical Entity Mention (AnEM) test corpus containing abstracts and full-text biomedical papers from Ohta et al. (ACL 2012)"
+    url: https://github.com/juand-r/entity-recognition-datasets/blob/master/data/AnEM/CONLL-format/data/AnEM.test
+
+commands:
+  - name: "convert-wnut17-ents"
+    help: "Convert WNUT17 dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-test.iob corpus/ner/
+        --use-ents
+    deps:
+      - assets/wnut17-train.iob
+      - assets/wnut17-dev.iob
+      - assets/wnut17-test.iob
+    outputs:
+      - corpus/ner/wnut17-train.spacy
+      - corpus/ner/wnut17-dev.spacy
+      - corpus/ner/wnut17-test.spacy
+
+  - name: "convert-wnut17-spans"
+    help: "Convert WNUT17 dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+      - >-
+        python -m scripts.convert_to_spans
+        assets/wnut17-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+    deps:
+      - assets/wnut17-train.iob
+      - assets/wnut17-dev.iob
+      - assets/wnut17-test.iob
+    outputs:
+      - corpus/spancat/wnut17-train.spacy
+      - corpus/spancat/wnut17-dev.spacy
+      - corpus/spancat/wnut17-test.spacy
+
+  - name: "inspect-wnut17"
+    help: "Analyze span-characteristics"
+    script:
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/wnut17-train.spacy 
+        --paths.dev corpus/spancat/wnut17-dev.spacy
+
+  - name: "clean-wikineural"
+    help: "Remove unnecessary indices from wikineural data"
+    script:
+      # Clean Wikineural datasets
+      - python -m scripts.preprocess assets/raw-de-wikineural-train.iob assets/de-wikineural-train.iob
+      - python -m scripts.preprocess assets/raw-de-wikineural-dev.iob assets/de-wikineural-dev.iob
+      - python -m scripts.preprocess assets/raw-de-wikineural-test.iob assets/de-wikineural-test.iob
+      - python -m scripts.preprocess assets/raw-en-wikineural-train.iob assets/en-wikineural-train.iob
+      - python -m scripts.preprocess assets/raw-en-wikineural-dev.iob assets/en-wikineural-dev.iob
+      - python -m scripts.preprocess assets/raw-en-wikineural-test.iob assets/en-wikineural-test.iob
+      - python -m scripts.preprocess assets/raw-es-wikineural-train.iob assets/es-wikineural-train.iob
+      - python -m scripts.preprocess assets/raw-es-wikineural-dev.iob assets/es-wikineural-dev.iob
+      - python -m scripts.preprocess assets/raw-es-wikineural-test.iob assets/es-wikineural-test.iob
+      - python -m scripts.preprocess assets/raw-nl-wikineural-train.iob assets/nl-wikineural-train.iob
+      - python -m scripts.preprocess assets/raw-nl-wikineural-dev.iob assets/nl-wikineural-dev.iob
+      - python -m scripts.preprocess assets/raw-nl-wikineural-test.iob assets/nl-wikineural-test.iob
+    deps:
+      # Wikineural datasets
+      - assets/raw-de-wikineural-train.iob
+      - assets/raw-de-wikineural-dev.iob
+      - assets/raw-en-wikineural-train.iob
+      - assets/raw-en-wikineural-dev.iob
+      - assets/raw-en-wikineural-test.iob
+      - assets/raw-es-wikineural-train.iob
+      - assets/raw-es-wikineural-dev.iob
+      - assets/raw-es-wikineural-test.iob
+      - assets/raw-nl-wikineural-train.iob
+      - assets/raw-nl-wikineural-dev.iob
+      - assets/raw-nl-wikineural-test.iob
+    outputs:
+      # Cleaned Wikineural datasets
+      - assets/de-wikineural-train.iob
+      - assets/de-wikineural-dev.iob
+      - assets/en-wikineural-train.iob
+      - assets/en-wikineural-dev.iob
+      - assets/en-wikineural-test.iob
+      - assets/es-wikineural-train.iob
+      - assets/es-wikineural-dev.iob
+      - assets/es-wikineural-test.iob
+      - assets/nl-wikineural-train.iob
+      - assets/nl-wikineural-dev.iob
+      - assets/nl-wikineural-test.iob
+
+  - name: "convert-wikineural-spans"
+    help: "Convert WikiNeural dataset (de, en, es, nl) into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+    deps:
+      - "assets/de-wikineural-train.iob"
+      - "assets/de-wikineural-dev.iob"
+      - "assets/de-wikineural-test.iob"
+      - "assets/en-wikineural-train.iob"
+      - "assets/en-wikineural-dev.iob"
+      - "assets/en-wikineural-test.iob"
+      - "assets/es-wikineural-train.iob"
+      - "assets/es-wikineural-dev.iob"
+      - "assets/es-wikineural-test.iob"
+      - "assets/nl-wikineural-train.iob"
+      - "assets/nl-wikineural-dev.iob"
+      - "assets/nl-wikineural-test.iob"
+    outputs:
+      - "corpus/spancat/de-wikineural-train.spacy"
+      - "corpus/spancat/de-wikineural-dev.spacy"
+      - "corpus/spancat/de-wikineural-test.spacy"
+      - "corpus/spancat/en-wikineural-train.spacy"
+      - "corpus/spancat/en-wikineural-dev.spacy"
+      - "corpus/spancat/en-wikineural-test.spacy"
+      - "corpus/spancat/es-wikineural-train.spacy"
+      - "corpus/spancat/es-wikineural-dev.spacy"
+      - "corpus/spancat/es-wikineural-test.spacy"
+      - "corpus/spancat/nl-wikineural-train.spacy"
+      - "corpus/spancat/nl-wikineural-dev.spacy"
+      - "corpus/spancat/nl-wikineural-test.spacy"
+
+  - name: "convert-wikineural-ents"
+    help: "Convert WikiNeural dataset (de, en, es, nl) into the spaCy format"
+    script:
+      # Convert de dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-wikineural-test.iob corpus/spancat/
+        --use-ents
+      # Convert en dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-wikineural-test.iob corpus/ner/
+        --use-ents
+      # Convert es dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-wikineural-test.iob corpus/ner/
+        --use-ents
+      # Convert nl dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-wikineural-test.iob corpus/ner/
+        --use-ents
+    deps:
+      - "assets/de-wikineural-train.iob"
+      - "assets/de-wikineural-dev.iob"
+      - "assets/de-wikineural-test.iob"
+      - "assets/en-wikineural-train.iob"
+      - "assets/en-wikineural-dev.iob"
+      - "assets/en-wikineural-test.iob"
+      - "assets/es-wikineural-train.iob"
+      - "assets/es-wikineural-dev.iob"
+      - "assets/es-wikineural-test.iob"
+      - "assets/nl-wikineural-train.iob"
+      - "assets/nl-wikineural-dev.iob"
+      - "assets/nl-wikineural-test.iob"
+    outputs:
+      - "corpus/ner/de-wikineural-train.spacy"
+      - "corpus/ner/de-wikineural-dev.spacy"
+      - "corpus/spancat/de-wikineural-test.spacy"
+      - "corpus/ner/en-wikineural-train.spacy"
+      - "corpus/ner/en-wikineural-dev.spacy"
+      - "corpus/ner/en-wikineural-test.spacy"
+      - "corpus/ner/es-wikineural-train.spacy"
+      - "corpus/ner/es-wikineural-dev.spacy"
+      - "corpus/ner/es-wikineural-test.spacy"
+      - "corpus/ner/nl-wikineural-train.spacy"
+      - "corpus/ner/nl-wikineural-dev.spacy"
+      - "corpus/ner/nl-wikineural-test.spacy"
+  
+  - name: "inspect-wikineural"
+    help: "Analyze span-characteristics"
+    script:
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/de-wikineural-train.spacy 
+        --paths.dev corpus/spancat/de-wikineural-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/en-wikineural-train.spacy 
+        --paths.dev corpus/spancat/en-wikineural-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/es-wikineural-train.spacy 
+        --paths.dev corpus/spancat/es-wikineural-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/nl-wikineural-train.spacy 
+        --paths.dev corpus/spancat/nl-wikineural-dev.spacy
+
+
+  - name: "clean-conll"
+    help: "Remove unnecessary indices from ConLL data"
+    script:
+      # Clean CoNLL datasets
+      - python -m scripts.preprocess assets/raw-de-conll-train.iob assets/de-conll-train.iob
+      - python -m scripts.preprocess assets/raw-de-conll-dev.iob assets/de-conll-dev.iob
+      - python -m scripts.preprocess assets/raw-de-conll-test.iob assets/de-conll-test.iob
+      - python -m scripts.preprocess assets/raw-en-conll-train.iob assets/en-conll-train.iob
+      - python -m scripts.preprocess assets/raw-en-conll-dev.iob assets/en-conll-dev.iob
+      - python -m scripts.preprocess assets/raw-en-conll-test.iob assets/en-conll-test.iob
+      - python -m scripts.preprocess assets/raw-es-conll-train.iob assets/es-conll-train.iob
+      - python -m scripts.preprocess assets/raw-es-conll-dev.iob assets/es-conll-dev.iob
+      - python -m scripts.preprocess assets/raw-es-conll-test.iob assets/es-conll-test.iob
+      - python -m scripts.preprocess assets/raw-nl-conll-train.iob assets/nl-conll-train.iob
+      - python -m scripts.preprocess assets/raw-nl-conll-dev.iob assets/nl-conll-dev.iob
+      - python -m scripts.preprocess assets/raw-nl-conll-test.iob assets/nl-conll-test.iob
+    deps:
+      # CoNLL datasets
+      - assets/raw-de-conll-train.iob
+      - assets/raw-de-conll-dev.iob
+      - assets/raw-en-conll-train.iob
+      - assets/raw-en-conll-dev.iob
+      - assets/raw-en-conll-test.iob
+      - assets/raw-es-conll-train.iob
+      - assets/raw-es-conll-dev.iob
+      - assets/raw-es-conll-test.iob
+      - assets/raw-nl-conll-train.iob
+      - assets/raw-nl-conll-dev.iob
+      - assets/raw-nl-conll-test.iob
+    outputs:
+      # Cleaned CoNLL datasets
+      - assets/de-conll-train.iob
+      - assets/de-conll-dev.iob
+      - assets/en-conll-train.iob
+      - assets/en-conll-dev.iob
+      - assets/en-conll-test.iob
+      - assets/es-conll-train.iob
+      - assets/es-conll-dev.iob
+      - assets/es-conll-test.iob
+      - assets/nl-conll-train.iob
+      - assets/nl-conll-dev.iob
+      - assets/nl-conll-test.iob
+
+  - name: "convert-conll-spans"
+    help: "Convert CoNLL dataset (de, en, es, nl) into the spaCy format"
+    script:
+      # Convert de dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      # Convert en dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      # Convert es dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      # Convert nl dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-dev.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+    deps:
+      - "assets/de-conll-train.iob"
+      - "assets/de-conll-dev.iob"
+      - "assets/de-conll-test.iob"
+      - "assets/en-conll-train.iob"
+      - "assets/en-conll-dev.iob"
+      - "assets/en-conll-test.iob"
+      - "assets/es-conll-train.iob"
+      - "assets/es-conll-dev.iob"
+      - "assets/es-conll-test.iob"
+      - "assets/nl-conll-train.iob"
+      - "assets/nl-conll-dev.iob"
+      - "assets/nl-conll-test.iob"
+    outputs:
+      - "corpus/spancat/de-conll-train.spacy"
+      - "corpus/spancat/de-conll-dev.spacy"
+      - "corpus/spancat/de-conll-test.spacy"
+      - "corpus/spancat/en-conll-train.spacy"
+      - "corpus/spancat/en-conll-dev.spacy"
+      - "corpus/spancat/en-conll-test.spacy"
+      - "corpus/spancat/es-conll-train.spacy"
+      - "corpus/spancat/es-conll-dev.spacy"
+      - "corpus/spancat/es-conll-test.spacy"
+      - "corpus/spancat/nl-conll-train.spacy"
+      - "corpus/spancat/nl-conll-dev.spacy"
+      - "corpus/spancat/nl-conll-test.spacy"
+
+  - name: "convert-conll-ents"
+    help: "Convert CoNLL dataset (de, en, es, nl) into the spaCy format"
+    script:
+      # Convert de dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/de-conll-test.iob corpus/spancat/
+        --converter auto
+      # Convert en dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/en-conll-test.iob corpus/ner/
+        --use-ents
+      # Convert es dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/es-conll-test.iob corpus/ner/
+        --use-ents
+      # Convert nl dataset
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-train.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-dev.iob corpus/ner/
+        --use-ents
+      - >-
+        python -m scripts.convert_to_spans
+        assets/nl-conll-test.iob corpus/ner/
+        --use-ents
+    deps:
+      - "assets/de-conll-train.iob"
+      - "assets/de-conll-dev.iob"
+      - "assets/de-conll-test.iob"
+      - "assets/en-conll-train.iob"
+      - "assets/en-conll-dev.iob"
+      - "assets/en-conll-test.iob"
+      - "assets/es-conll-train.iob"
+      - "assets/es-conll-dev.iob"
+      - "assets/es-conll-test.iob"
+      - "assets/nl-conll-train.iob"
+      - "assets/nl-conll-dev.iob"
+      - "assets/nl-conll-test.iob"
+    outputs:
+      - "corpus/ner/de-conll-train.spacy"
+      - "corpus/ner/de-conll-dev.spacy"
+      - "corpus/ner/de-conll-test.spacy"
+      - "corpus/ner/en-conll-train.spacy"
+      - "corpus/ner/en-conll-dev.spacy"
+      - "corpus/ner/en-conll-test.spacy"
+      - "corpus/ner/es-conll-train.spacy"
+      - "corpus/ner/es-conll-dev.spacy"
+      - "corpus/ner/es-conll-test.spacy"
+      - "corpus/ner/nl-conll-train.spacy"
+      - "corpus/ner/nl-conll-dev.spacy"
+      - "corpus/ner/nl-conll-test.spacy"
+  
+  - name: "inspect-conll"
+    help: "Analyze span-characteristics"
+    script:
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/de-conll-train.spacy 
+        --paths.dev corpus/spancat/de-conll-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/en-conll-train.spacy 
+        --paths.dev corpus/spancat/en-conll-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/es-conll-train.spacy 
+        --paths.dev corpus/spancat/es-conll-dev.spacy
+      
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/nl-conll-train.spacy 
+        --paths.dev corpus/spancat/nl-conll-dev.spacy
+
+  - name: "convert-archaeo-spans"
+    help: "Convert Dutch Archaeology dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/archaeo.bio corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter iob
+      - >-
+        python -m scripts.split_docs
+        corpus/spancat/archaeo.spacy corpus/spancat
+        --seed 42
+        --shuffle
+    deps:
+      - "assets/archaeo.bio"
+    outputs:
+      - "corpus/spancat/archaeo-train.spacy"
+      - "corpus/spancat/archaeo-dev.spacy"
+      - "corpus/spancat/archaeo-test.spacy"
+
+  - name: "convert-archaeo-ents"
+    help: "Convert Dutch Archaeology dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/archaeo.bio corpus/ner/
+        --use-ents
+        --converter iob
+      - >-
+        python -m scripts.split_docs
+        corpus/ner/archaeo.spacy corpus/ner/
+        --seed 42
+        --shuffle
+    deps:
+      - "assets/archaeo.bio"
+    outputs:
+      - "corpus/ner/archaeo-train.spacy"
+      - "corpus/ner/archaeo-dev.spacy"
+      - "corpus/ner/archaeo-test.spacy"
+  
+  - name: "inspect-archaeo"
+    help: "Analyze span-characteristics"
+    script:
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/archaeo-train.spacy 
+        --paths.dev corpus/spancat/archaeo-dev.spacy
+
+  - name: "convert-anem-spans"
+    help: "Convert AnEM dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/anem-train.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+        --train-size 0.8
+        --seed 42
+        --shuffle
+      - mv corpus/spancat/anem-train-dev.spacy corpus/spancat/anem-dev.spacy
+      - >-
+        python -m scripts.convert_to_spans
+        assets/anem-test.iob corpus/spancat/
+        --spans-key ${vars.spans_key}
+        --converter auto
+    deps:
+      - assets/anem-train.iob
+      - assets/anem-test.iob
+    outputs:
+      - corpus/spancat/anem-train.spacy
+      - corpus/spancat/anem-dev.spacy
+      - corpus/spancat/anem-test.spacy
+  
+
+  - name: "convert-anem-ents"
+    help: "Convert AnEM dataset into the spaCy format"
+    script:
+      - >-
+        python -m scripts.convert_to_spans
+        assets/anem-train.iob corpus/ner/
+        --use-ents
+        --converter auto
+        --train-size 0.8
+        --seed 42
+        --shuffle
+      - mv corpus/ner/anem-train-dev.spacy corpus/ner/anem-dev.spacy
+      - >-
+        python -m scripts.convert_to_spans
+        assets/anem-test.iob corpus/ner/
+        --use-ents
+        --converter auto
+    deps:
+      - assets/anem-train.iob
+      - assets/anem-test.iob
+    outputs:
+      - corpus/ner/anem-train.spacy
+      - corpus/ner/anem-dev.spacy
+      - corpus/ner/anem-test.spacy
+  
+  - name: "inspect-anem"
+    help: "Analyze span-characteristics"
+    script:
+      - >-
+        python -m spacy debug data configs/spancat_default.cfg 
+        --paths.train corpus/spancat/anem-train.spacy 
+        --paths.dev corpus/spancat/anem-dev.spacy
+
+  - name: "clean"
+    help: "Remove intermediary files"
+    script:
+      - "rm -rf assets/*"
+      - "rm -rf corpus/*"

--- a/pipelines/spancat-datasets/scripts/convert_to_spans.py
+++ b/pipelines/spancat-datasets/scripts/convert_to_spans.py
@@ -1,0 +1,182 @@
+"""Monkey-patched version of the convert command that transfers entities to Doc.spans"""
+
+import random
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+import srsly
+import typer
+from spacy.cli.convert import CONVERTERS, _get_converter, _write_docs_to_file
+from spacy.cli.convert import verify_cli_args, walk_directory
+from spacy.tokens import Doc, DocBin, SpanGroup
+from wasabi import Printer
+
+FILE_TYPE = "spacy"
+Arg = typer.Argument
+Opt = typer.Option
+
+
+def convert_cli(
+    # fmt: off
+    input_path: str = Arg(..., help="Input file or directory", exists=True),
+    output_dir: Path = Arg("-", help="Output directory. '-' for stdout.", allow_dash=True, exists=True),
+    spans_key: str = Opt("sc", "--spans-key", "-sc", help="Spans key to use when storing entities"),
+    n_sents: int = Opt(1, "--n-sents", "-n", help="Number of sentences per doc (0 to disable)"),
+    seg_sents: bool = Opt(False, "--seg-sents", "-s", help="Segment sentences (for -c ner)"),
+    model: Optional[str] = Opt(None, "--model", "--base", "-b", help="Trained spaCy pipeline for sentence segmentation to use as base (for --seg-sents)"),
+    morphology: bool = Opt(False, "--morphology", "-m", help="Enable appending morphology to tags"),
+    merge_subtokens: bool = Opt(False, "--merge-subtokens", "-T", help="Merge CoNLL-U subtokens"),
+    converter: str = Opt("auto", "--converter", "-c", help=f"Converter: {tuple(CONVERTERS.keys())}"),
+    ner_map: Optional[Path] = Opt(None, "--ner-map", "-nm", help="NER tag mapping (as JSON-encoded dict of entity types)", exists=True),
+    lang: Optional[str] = Opt(None, "--lang", "-l", help="Language (if tokenizer required)"),
+    use_ents: bool = Opt(False, "--use-ents", "-e", help="Use Doc.ents, don't transfer to Doc.spans"),
+    train_size: Optional[float] = Opt(None, "--train-size", "-sz", help="Size of the training dataset for splitting"),
+    shuffle: bool = Opt(False, "--shuffle", "-sf", help="Shuffle the dataset before splitting"),
+    seed: Optional[int] = Opt(None, "--seed", "-sd", help="Random seed for shuffling the data")
+    # fmt: on
+):
+    """
+    Convert files into json or DocBin format for training. The resulting .spacy
+    file can be used with the train command and other experiment management
+    functions.
+
+    If no output_dir is specified and the output format is JSON, the data
+    is written to stdout, so you can pipe them forward to a JSON file:
+    $ spacy convert some_file.conllu --file-type json > some_file.json
+
+    NOTE: This is a monkeypatched version of the original `convert` command.
+    Here, we added an additional step that transfers the entitites into
+    the Doc.spans attribute for Span Categorization.
+
+    DOCS: https://spacy.io/api/cli#convert
+    """
+    input_path = Path(input_path)
+    output_dir: Union[str, Path] = "-" if output_dir == Path("-") else output_dir
+    silent = output_dir == "-"
+    msg = Printer(no_print=silent)
+    verify_cli_args(msg, input_path, output_dir, FILE_TYPE, converter, ner_map)
+    converter = _get_converter(msg, converter, input_path)
+    convert(
+        input_path,
+        output_dir,
+        n_sents=n_sents,
+        seg_sents=seg_sents,
+        model=model,
+        morphology=morphology,
+        merge_subtokens=merge_subtokens,
+        converter=converter,
+        ner_map=ner_map,
+        lang=lang,
+        silent=silent,
+        msg=msg,
+        spans_key=spans_key,
+        use_ents=use_ents,
+        train_size=train_size,
+        shuffle=shuffle,
+        seed=seed,
+    )
+
+
+def transfer_ents_to_spans(docs: Iterable[Doc], spans_key: str) -> Iterable[Doc]:
+    _docs = []
+    for doc in docs:
+        spans = [ent for ent in doc.ents]
+        group = SpanGroup(doc, name=spans_key, spans=spans)
+        doc.spans[spans_key] = group
+        doc.set_ents([])
+        _docs.append(doc)
+    return _docs
+
+
+def _save_docs_to_disk(
+    docs: Iterable[Doc],
+    output_dir: Union[str, Path],
+    input_loc: Path,
+    is_dev: bool,
+    msg: Printer,
+):
+    db = DocBin(docs=docs, store_user_data=True)
+    len_docs = len(db)
+    data = db.to_bytes()  # type: ignore[assignment]
+
+    if is_dev:
+        filename = input_loc.stem + "-dev" + input_loc.suffix
+    else:
+        filename = input_loc.parts[-1]
+
+    output_file = Path(output_dir) / filename
+    output_file = output_file.with_suffix(f".{FILE_TYPE}")
+    _write_docs_to_file(data, output_file, FILE_TYPE)
+    msg.good(f"Generated output file ({len_docs} documents): {output_file}")
+
+
+def convert(
+    input_path: Path,
+    output_dir: Union[str, Path],
+    *,
+    n_sents: int = 1,
+    seg_sents: bool = False,
+    model: Optional[str] = None,
+    morphology: bool = False,
+    merge_subtokens: bool = False,
+    converter: str = "auto",
+    ner_map: Optional[Path] = None,
+    lang: Optional[str] = None,
+    silent: bool = True,
+    msg: Optional[Printer] = None,
+    spans_key: str = "sc",
+    use_ents: bool = False,
+    train_size: Optional[float] = None,
+    shuffle: bool = True,
+    seed: Optional[int] = None,
+) -> None:
+    input_path = Path(input_path)
+    if not msg:
+        msg = Printer(no_print=silent)
+    ner_map = srsly.read_json(ner_map) if ner_map is not None else None
+    for input_loc in walk_directory(input_path, converter):
+        with input_loc.open("r", encoding="utf-8") as infile:
+            input_data = infile.read()
+        # Use converter function to convert data
+        func = CONVERTERS[converter]
+        docs = func(
+            input_data,
+            n_sents=n_sents,
+            seg_sents=seg_sents,
+            append_morphology=morphology,
+            merge_subtokens=merge_subtokens,
+            lang=lang,
+            model=model,
+            no_print=silent,
+            ner_map=ner_map,
+        )
+        docs = list(docs)
+        # Monkeypatched version converting docs to spans
+        if not use_ents:
+            msg.info("Transferring entities to doc.spans")
+            docs = transfer_ents_to_spans(docs, spans_key)
+
+        if train_size:
+            msg.info(f"Splitting files with train_size {train_size}")
+            if shuffle:
+                if seed:
+                    msg.info(f"Using random seed {seed}")
+                    random.seed(seed)
+                msg.info("Shuffling the documents before splitting")
+                random.shuffle(docs)
+            num_training = int(train_size * len(docs))
+            train_docs = docs[:num_training]
+            dev_docs = docs[num_training:]
+            msg.text(
+                f"Dataset has been split with train size={len(train_docs)} "
+                f"and dev size={len(dev_docs)}"
+            )
+
+            _save_docs_to_disk(train_docs, output_dir, input_loc, is_dev=False, msg=msg)
+            _save_docs_to_disk(dev_docs, output_dir, input_loc, is_dev=True, msg=msg)
+        else:
+            _save_docs_to_disk(docs, output_dir, input_loc, is_dev=False, msg=msg)
+
+
+if __name__ == "__main__":
+    typer.run(convert_cli)

--- a/pipelines/spancat-datasets/scripts/preprocess.py
+++ b/pipelines/spancat-datasets/scripts/preprocess.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from string import digits
+
+import typer
+from wasabi import msg
+
+Arg = typer.Argument
+Opt = typer.Option
+
+
+def preprocess(input_path: Path, output_path: Path):
+    """Helper function to remove the indices for the WikiNeural dataset"""
+    with input_path.open() as f:
+        lines = f.readlines()
+    with output_path.open("w") as f:
+        for i, line in enumerate(lines):
+            # XXX bit weird, but line 9883 in the German ConLL dev set
+            # seems to be broken: it only has field O, but no string.
+            if i == 9883 and input_path.name == "raw-de-conll-test.iob":
+                continue
+            new_line = line if line == "\n" else line.lstrip(digits)[1:]
+            if new_line == "-DOCSTART-\tO\n":
+                new_line = "-DOCSTART- -X- O O\n"
+            f.write(new_line)
+    msg.good(f"Saved preprocessed data to {output_path}")
+
+
+if __name__ == "__main__":
+    typer.run(preprocess)

--- a/pipelines/spancat-datasets/scripts/split_docs.py
+++ b/pipelines/spancat-datasets/scripts/split_docs.py
@@ -1,0 +1,81 @@
+"""Split a spaCy-formatted file into train, dev, and test partitions"""
+
+from pathlib import Path
+from typing import Tuple, Optional, Any, List
+
+import random
+import typer
+import spacy
+from math import ceil
+from spacy.tokens import DocBin
+from wasabi import msg
+
+Arg = typer.Argument
+Opt = typer.Option
+
+
+def _train_dev_test_split(
+    data: List[Any],
+    train_size,
+    dev_size: float,
+    test_size: float,
+    shuffle: Optional[bool] = False,
+    seed: Optional[int] = None,
+) -> Tuple[List[Any], List[Any]]:
+    if shuffle:
+        if not seed:
+            raise ValueError("Must provide 'seed' when 'shuffle = True'")
+        rng = random.Random(seed)
+        rng.shuffle(data)
+    n_samples = len(data)
+    n_test = ceil(test_size * n_samples)
+    n_dev = ceil(dev_size * n_samples)
+    n_train = n_samples - (n_test + n_dev)
+    train = data[:n_train]
+    dev = data[n_train:n_train+n_dev]
+    test = data[n_train+n_dev:]
+    return train, dev, test
+
+
+def split_docs(
+    # fmt: off
+    input_path: Path,
+    output_dir: Path,
+    split_size: Tuple[float, float, float] = Arg((0.8, 0.1, 0.1), help="Split sizes for train/dev/test respectively"),
+    shuffle: bool = Opt(False, "--shuffle", "-sf", help="Shuffle the dataset before splitting"),
+    seed: Optional[int] = Opt(None, "--seed", "-sd", help="Random seed for shuffling the data")
+    # fmt: on
+):
+    if sum(split_size) != 1.0:
+        msg.fail(
+            "Split sizes for train, dev, and test should sum up to 1.0 "
+            f"({' + '.join(map(str, split_size))} != 1.0)",
+            exits=1,
+        )
+
+    nlp = spacy.blank("xx")
+    db = DocBin().from_disk(input_path)
+    docs = list(db.get_docs(nlp.vocab))
+    msg.info(f"Found {len(docs)} docs in {input_path}")
+
+    train_size, dev_size, test_size = split_size
+    msg.info(f"Splitting docs using sizes: {split_size}")
+    train, dev, test = _train_dev_test_split(
+        docs, train_size, dev_size, test_size, shuffle, seed
+    )
+    datasets = {"train": train, "dev": dev, "test": test}
+
+    msg.text(
+        f"Done splitting the train ({len(train)}), dev ({len(dev)}), "
+        f" and test ({len(test)}) datasets!"
+    )
+
+    for dataset, docs in datasets.items():
+        output_path = output_dir / f"{input_path.stem}-{dataset}.spacy"
+        db_new = DocBin(docs=docs)
+        db_new.to_disk(output_path)
+        msg.good(f"Saved {dataset} ({len(docs)}) dataset to {output_path}")
+
+
+if __name__ == "__main__":
+    typer.run(split_docs)

--- a/pipelines/spancat-datasets/scripts/view_spans.py
+++ b/pipelines/spancat-datasets/scripts/view_spans.py
@@ -1,0 +1,37 @@
+import random
+from pathlib import Path
+
+import typer
+from spacy.tokens import DocBin
+from spacy.util import get_lang_class
+from wasabi import msg
+
+Arg = typer.Argument
+Opt = typer.Option
+
+
+def view_spans(
+    # fmt: off
+    input_path: Path = Arg(..., help="Input spaCy file", exists=True),
+    lang: str = Opt("xx", "--lang", "-l", help="Language for the vocab"),
+    display_size: int = Opt(3, "--size", "-sz", help="Number of Doc.spans to show"),
+    shuffle: bool = Opt(False, "--shuffle", "-s", help="Shuffle the items")
+    # fmt: on
+):
+    """Helper function to check if spans were saved correctly"""
+    nlp = get_lang_class(lang)()
+    db = DocBin().from_disk(input_path)
+    docs = list(db.get_docs(nlp.vocab))
+    msg.info(f"Found {len(docs)} docs in {str(input_path)}")
+    msg.info(f"Showing {display_size} docs")
+
+    if shuffle:
+        random.shuffle(docs)
+    for doc in docs[:display_size]:
+        msg.divider()
+        msg.text(doc.text)
+        msg.text(doc.spans, color="yellow")
+
+
+if __name__ == "__main__":
+    typer.run(view_spans)


### PR DESCRIPTION
This is a project that is meant to help with experimenting with the `spancat` and `ner` components. Currently it has:

1. ConLL (English, German, Spanish, Dutch)
2. WiniNeuRal (English, German, Spanish, Dutch)
3. Dutch Archeology data set
4. AnEM
5. Wnut 2017

For the archeology data set it creates a random train/dev/test split and for all other data sets it uses the standard splits. It has a small utility `view_spans.py` to show a couple of random examples on the command line from a data set and runs `debug data` with the a default `spancat` config to show the span-characteristics.

The idea is to have a home for the `spancat`/`ner` data sets to be able to easily benchmark components on them. Plus others can use these data sets perhaps for pre-training.