### PR TITLE
Don't do pip user installs

### DIFF
--- a/experimental/ner_spancat_compare/project.yml
+++ b/experimental/ner_spancat_compare/project.yml
@@ -147,7 +147,7 @@ commands:
   - name: "install"
     help: "Install dependencies"
     script:
-      - "pip install --user -r requirements.txt"
+      - "pip install -r requirements.txt"
       - "python -m spacy download en_core_web_lg"
   - name: "convert"
     help: "Convert IOB file into the spaCy format"

--- a/tutorials/ner_tweets/project.yml
+++ b/tutorials/ner_tweets/project.yml
@@ -126,7 +126,7 @@ commands:
   - name: "install"
     help: "Install dependencies"
     script: 
-      - "pip3 install --user -r requirements.txt"
+      - "pip install -r requirements.txt"
       - "python -m spacy download en_core_web_lg"
   - name: "preprocess"
     help: "Convert raw inputs into spaCy's binary format"


### PR DESCRIPTION
Pip user installs go to a location that's not project specific and don't work in ordinary virtualenvs.

Additionally, since we normalize pip/pip3 in our projects run code, we don't need to use pip3 in scripts.