### PR TITLE
Allow ml_datasets 0.2.0

### DIFF
--- a/benchmarks/textcat_architectures/requirements.txt
+++ b/benchmarks/textcat_architectures/requirements.txt
@@ -1,1 +1,1 @@
-ml_datasets==0.2.0a0
+ml_datasets>=0.2.0a0

--- a/integrations/wandb/requirements.txt
+++ b/integrations/wandb/requirements.txt
@@ -1,2 +1,2 @@
-ml_datasets==0.2.0a0
+ml_datasets>=0.2.0a0
 wandb>=0.12.4,<0.20.0


### PR DESCRIPTION
Two example projects were pinning `ml_datasets` to exactly `0.2.0a0` even though we've had a `0.2.0` release since then.