### PR TITLE
Use pysqlite3 instead of sqlite3 to allow for support of upsert syntax in Python 3.7

### DIFF
--- a/benchmarks/nel/requirements.txt
+++ b/benchmarks/nel/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 fuzzyset2
 spacyfishing
 virtualenv
+pysqlite3>=3.24.0

--- a/benchmarks/nel/requirements.txt
+++ b/benchmarks/nel/requirements.txt
@@ -5,4 +5,4 @@ scikit-learn
 fuzzyset2
 spacyfishing
 virtualenv
-pysqlite3>=3.24.0
+pysqlite3

--- a/benchmarks/nel/scripts/wiki/wiki_dump_api.py
+++ b/benchmarks/nel/scripts/wiki/wiki_dump_api.py
@@ -3,7 +3,7 @@ import os.path
 import pickle
 from pathlib import Path
 from typing import Dict, Optional, Any, Tuple, List, Set
-import sqlite3
+import pysqlite3 as sqlite3
 
 from schemas import Entity
 from wiki import wikidata, wikipedia

--- a/benchmarks/nel/scripts/wiki/wikidata.py
+++ b/benchmarks/nel/scripts/wiki/wikidata.py
@@ -5,7 +5,7 @@ Modified from https://github.com/explosion/projects/blob/master/nel-wikipedia/wi
 import bz2
 import io
 import json
-import sqlite3
+import pysqlite3 as sqlite3
 from pathlib import Path
 from typing import Union, Optional, Dict, Tuple, Any, List, Set, Iterator
 

--- a/benchmarks/nel/scripts/wiki/wikipedia.py
+++ b/benchmarks/nel/scripts/wiki/wikipedia.py
@@ -4,7 +4,7 @@ Modified from https://github.com/explosion/projects/blob/master/nel-wikipedia/wi
 
 import re
 import bz2
-import sqlite3
+import pysqlite3 as sqlite3
 
 from pathlib import Path
 from typing import Union, Optional, Tuple, List, Dict, Set, Any


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
The weekly build currently fails on BuildKite to the usage of Python 3.7 and the `sqlite3` version shipped with it due to its lack of support of the SQLite upsert syntax used in the NEL benchmark project.
Since upgrading `sqlite3` isn't easily possible independent from the Python installation itself, this PR replaces `sqlite3` with the drop-in support `pysqlite3`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
