### PR TITLE
Add minimal spancat demo

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,6 +1,6 @@
 <a href="https://explosion.ai"><img src="https://explosion.ai/assets/img/logo.svg" width="125" height="125" align="right" /></a>
 
-# 🪐 Project Templates: Pipelines (15)
+# 🪐 Project Templates: Pipelines (16)
 
 | Template | Description |
 | --- | --- |
@@ -15,6 +15,7 @@
 | [`parser_demo`](parser_demo) | Demo Dependency Parser |
 | [`parser_intent_demo`](parser_intent_demo) | Demo Intent Parser (Dependency Parser) |
 | [`polar_component`](polar_component) | Polar Component |
+| [`spancat_demo`](spancat_demo) | Demo spancat in a new pipeline (Span Categorization) |
 | [`tagger_parser_predicted_annotations`](tagger_parser_predicted_annotations) | Using Predicted Annotations in Subsequent Components |
 | [`tagger_parser_ud`](tagger_parser_ud) | Part-of-speech Tagging & Dependency Parsing (Universal Dependencies) |
 | [`textcat_demo`](textcat_demo) | Demo Textcat (Text Classification) |

--- a/pipelines/spancat_demo/.gitignore
+++ b/pipelines/spancat_demo/.gitignore
@@ -1,0 +1,4 @@
+configs
+corpus
+training
+packages

--- a/pipelines/spancat_demo/README.md
+++ b/pipelines/spancat_demo/README.md
@@ -22,8 +22,10 @@ Commands are only re-run if their inputs have changed.
 | `convert` | Convert the data to spaCy's binary format |
 | `create-config` | Create a new config with a spancat pipeline component |
 | `train` | Train the spancat model |
+| `train-with-vectors` | Train the spancat model with vectors |
 | `evaluate` | Evaluate the model and export metrics |
 | `package` | Package the trained model as a pip package |
+| `clean` | Remove intermediary directories |
 
 ### ⏭ Workflows
 
@@ -35,6 +37,7 @@ inputs have changed.
 | Workflow | Steps |
 | --- | --- |
 | `all` | `convert` &rarr; `create-config` &rarr; `train` &rarr; `evaluate` |
+| `all-vectors` | `download` &rarr; `convert` &rarr; `create-config` &rarr; `train-with-vectors` &rarr; `evaluate` |
 
 ### 🗂 Assets
 
@@ -44,7 +47,7 @@ in the project directory.
 
 | File | Source | Description |
 | --- | --- | --- |
-| [`assets/train.json`](assets/train.json) | Local | Demo training data converted from the v2 `train_ner.py` example with `srsly.write_json("train.json", TRAIN_DATA)` |
+| [`assets/train.json`](assets/train.json) | Local | Demo training data adapted from the `ner_demo` project |
 | [`assets/dev.json`](assets/dev.json) | Local | Demo development data |
 
 <!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/pipelines/spancat_demo/README.md
+++ b/pipelines/spancat_demo/README.md
@@ -1,0 +1,50 @@
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS START (do not remove) -->
+
+# 🪐 spaCy Project: Demo spancat in a new pipeline (Span Categorization)
+
+A minimal demo spancat project for spaCy v3
+
+## 📋 project.yml
+
+The [`project.yml`](project.yml) defines the data assets required by the
+project, as well as the available commands and workflows. For details, see the
+[spaCy projects documentation](https://spacy.io/usage/projects).
+
+### ⏯ Commands
+
+The following commands are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run).
+Commands are only re-run if their inputs have changed.
+
+| Command | Description |
+| --- | --- |
+| `download` | Download a spaCy model with pretrained vectors |
+| `convert` | Convert the data to spaCy's binary format |
+| `create-config` | Create a new config with a spancat pipeline component |
+| `train` | Train the spancat model |
+| `evaluate` | Evaluate the model and export metrics |
+| `package` | Package the trained model as a pip package |
+
+### ⏭ Workflows
+
+The following workflows are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run)
+and will run the specified commands in order. Commands are only re-run if their
+inputs have changed.
+
+| Workflow | Steps |
+| --- | --- |
+| `all` | `convert` &rarr; `create-config` &rarr; `train` &rarr; `evaluate` |
+
+### 🗂 Assets
+
+The following assets are defined by the project. They can
+be fetched by running [`spacy project assets`](https://spacy.io/api/cli#project-assets)
+in the project directory.
+
+| File | Source | Description |
+| --- | --- | --- |
+| [`assets/train.json`](assets/train.json) | Local | Demo training data converted from the v2 `train_ner.py` example with `srsly.write_json("train.json", TRAIN_DATA)` |
+| [`assets/dev.json`](assets/dev.json) | Local | Demo development data |
+
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/pipelines/spancat_demo/assets/.gitattributes
+++ b/pipelines/spancat_demo/assets/.gitattributes
@@ -1,0 +1,6 @@
+# This is needed to ensure that text-based assets included with project
+# templates and cloned via Git end up with consistent line endings and
+# the same checksums. It will prevent Git from converting line endings.
+# Otherwise, a user cloning assets on Windows may end up with a different
+# checksum due to different line endings.
+*	-text

--- a/pipelines/spancat_demo/assets/dev.json
+++ b/pipelines/spancat_demo/assets/dev.json
@@ -1,0 +1,26 @@
+[
+  [
+    "Where is Berlin?",
+    {
+      "entities":[
+        [
+          9,
+          15,
+          "LOC"
+        ]
+      ]
+    }
+  ],
+  [
+    "I like Shaka Khan.",
+    {
+      "entities":[
+        [
+          7,
+          17,
+          "PERSON"
+        ]
+      ]
+    }
+  ]
+]

--- a/pipelines/spancat_demo/assets/train.json
+++ b/pipelines/spancat_demo/assets/train.json
@@ -1,0 +1,31 @@
+[
+  [
+    "Who is Shaka Khan?",
+    {
+      "entities":[
+        [
+          7,
+          17,
+          "PERSON"
+        ]
+      ]
+    }
+  ],
+  [
+    "I like London and Berlin.",
+    {
+      "entities":[
+        [
+          7,
+          13,
+          "LOC"
+        ],
+        [
+          18,
+          24,
+          "LOC"
+        ]
+      ]
+    }
+  ]
+]

--- a/pipelines/spancat_demo/assets/train.json
+++ b/pipelines/spancat_demo/assets/train.json
@@ -27,5 +27,17 @@
         ]
       ]
     }
+  ],
+  [
+    "Have you been to London?",
+    {
+      "entities":[
+        [
+          17,
+          23,
+          "LOC"
+        ]
+      ]
+    }
   ]
 ]

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -80,7 +80,7 @@ commands:
         python -m spacy train configs/config.cfg --output training/ 
         --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy 
         --training.eval_frequency 10 
-        --training.patience 500 
+        --training.patience 100 
         --gpu-id ${vars.gpu_id}
         --system.seed ${vars.seed}
     deps:
@@ -97,7 +97,7 @@ commands:
         python -m spacy train configs/config.cfg --output training/ 
         --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy 
         --training.eval_frequency 10 
-        --training.patience 1500 
+        --training.patience 100 
         --gpu-id ${vars.gpu_id} 
         --initialize.vectors ${vars.vectors_model} 
         --system.seed ${vars.seed}

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -34,6 +34,12 @@ workflows:
     - create-config
     - train
     - evaluate
+  all-vectors:
+    - download
+    - convert
+    - create-config
+    - train-with-vectors
+    - evaluate
 
 # Project commands, specified in a style similar to CI config files (e.g. Azure
 # pipelines). The name is the command name that lets you trigger the command
@@ -76,6 +82,17 @@ commands:
     outputs:
       - "training/model-best"
 
+  - name: "train-with-vectors"
+    help: "Train the spancat model with vectors"
+    script:
+      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 50 --gpu-id ${vars.gpu_id} --initialize.vectors ${vars.vectors_model} --components.tok2vec.model.embed.include_static_vectors true"
+    deps:
+      - "configs/config.cfg"
+      - "corpus/train.spacy"
+      - "corpus/dev.spacy"
+    outputs:
+      - "training/model-best"
+
   - name: "evaluate"
     help: "Evaluate the model and export metrics"
     script:
@@ -94,3 +111,10 @@ commands:
       - "training/model-best"
     outputs_no_cache:
       - "packages/${vars.lang}_${vars.name}-${vars.version}/dist/${vars.lang}_${vars.name}-${vars.version}.tar.gz"
+
+  - name: clean
+    help: "Remove intermediary directories"
+    script:
+      - "rm -rf corpus/*"
+      - "rm -rf training/*"
+      - "rm -rf metrics/*"

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -8,6 +8,8 @@ vars:
   train: "train.json"
   dev: "dev.json"
   version: "0.0.0"
+  # Set a random seed
+  seed: 0
   # Set your GPU ID, -1 is CPU
   gpu_id: -1
   # Vectors model for train-with-vectors
@@ -74,7 +76,13 @@ commands:
   - name: "train"
     help: "Train the spancat model"
     script:
-      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 500 --gpu-id ${vars.gpu_id}"
+      - >-
+        python -m spacy train configs/config.cfg --output training/ 
+        --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy 
+        --training.eval_frequency 10 
+        --training.patience 500 
+        --gpu-id ${vars.gpu_id}
+        --system.seed ${vars.seed}
     deps:
       - "configs/config.cfg"
       - "corpus/train.spacy"
@@ -85,7 +93,15 @@ commands:
   - name: "train-with-vectors"
     help: "Train the spancat model with vectors"
     script:
-      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 1500 --gpu-id ${vars.gpu_id} --initialize.vectors ${vars.vectors_model} --components.tok2vec.model.embed.include_static_vectors true"
+      - >-
+        python -m spacy train configs/config.cfg --output training/ 
+        --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy 
+        --training.eval_frequency 10 
+        --training.patience 1500 
+        --gpu-id ${vars.gpu_id} 
+        --initialize.vectors ${vars.vectors_model} 
+        --system.seed ${vars.seed}
+        --components.tok2vec.model.embed.include_static_vectors true
     deps:
       - "configs/config.cfg"
       - "corpus/train.spacy"

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -21,7 +21,7 @@ directories: ["assets", "corpus", "configs", "training", "scripts", "packages"]
 # them with the project, so they won't have to be downloaded.
 assets:
   - dest: "assets/train.json"
-    description: 'Demo training data converted from the v2 `train_ner.py` example with `srsly.write_json("train.json", TRAIN_DATA)`'
+    description: "Demo training data"
   - dest: "assets/dev.json"
     description: "Demo development data"
 

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -1,5 +1,5 @@
-title: "Demo Spancat in a new pipeline (Span Categorization)"
-description: "A minimal demo Spancat project for spaCy v3"
+title: "Demo spancat in a new pipeline (Span Categorization)"
+description: "A minimal demo spancat project for spaCy v3"
 
 # Variables can be referenced across the project.yml using ${vars.var_name}
 vars:

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -23,7 +23,7 @@ directories: ["assets", "corpus", "configs", "training", "scripts", "packages"]
 # them with the project, so they won't have to be downloaded.
 assets:
   - dest: "assets/train.json"
-    description: "Demo training data"
+    description: "Demo training data adapted from the `ner_demo` project"
   - dest: "assets/dev.json"
     description: "Demo development data"
 

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -1,0 +1,96 @@
+title: "Demo Spancat in a new pipeline (Span Categorization)"
+description: "A minimal demo Spancat project for spaCy v3"
+
+# Variables can be referenced across the project.yml using ${vars.var_name}
+vars:
+  name: "spancat_demo"
+  lang: "en"
+  train: "train.json"
+  dev: "dev.json"
+  version: "0.0.0"
+  # Set your GPU ID, -1 is CPU
+  gpu_id: -1
+  # Vectors model for train-with-vectors
+  vectors_model: "en_core_web_md"
+
+# These are the directories that the project needs. The project CLI will make
+# sure that they always exist.
+directories: ["assets", "corpus", "configs", "training", "scripts", "packages"]
+
+# Assets that should be downloaded or available in the directory. We're shipping
+# them with the project, so they won't have to be downloaded.
+assets:
+  - dest: "assets/train.json"
+    description: 'Demo training data converted from the v2 `train_ner.py` example with `srsly.write_json("train.json", TRAIN_DATA)`'
+  - dest: "assets/dev.json"
+    description: "Demo development data"
+
+# Workflows are sequences of commands (see below) executed in order. You can
+# run them via "spacy project run [workflow]". If a commands's inputs/outputs
+# haven't changed, it won't be re-run.
+workflows:
+  all:
+    - convert
+    - create-config
+    - train
+    - evaluate
+
+# Project commands, specified in a style similar to CI config files (e.g. Azure
+# pipelines). The name is the command name that lets you trigger the command
+# via "spacy project run [command] [path]". The help message is optional and
+# shown when executing "spacy project run [optional command] [path] --help".
+commands:
+  - name: "download"
+    help: "Download a spaCy model with pretrained vectors"
+    script:
+      - "python -m spacy download ${vars.vectors_model}"
+
+  - name: "convert"
+    help: "Convert the data to spaCy's binary format"
+    script:
+      - "python scripts/convert.py ${vars.lang} assets/${vars.train} corpus/train.spacy"
+      - "python scripts/convert.py ${vars.lang} assets/${vars.dev} corpus/dev.spacy"
+    deps:
+      - "assets/${vars.train}"
+      - "assets/${vars.dev}"
+      - "scripts/convert.py"
+    outputs:
+      - "corpus/train.spacy"
+      - "corpus/dev.spacy"
+
+  - name: "create-config"
+    help: "Create a new config with a spancat pipeline component"
+    script:
+      - "python -m spacy init config --lang ${vars.lang} --pipeline spancat configs/config.cfg --force"
+    outputs:
+      - "configs/config.cfg"
+
+  - name: "train"
+    help: "Train the spancat model"
+    script:
+      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 50 --gpu-id ${vars.gpu_id}"
+    deps:
+      - "configs/config.cfg"
+      - "corpus/train.spacy"
+      - "corpus/dev.spacy"
+    outputs:
+      - "training/model-best"
+
+  - name: "evaluate"
+    help: "Evaluate the model and export metrics"
+    script:
+      - "python -m spacy evaluate training/model-best corpus/dev.spacy --output training/metrics.json"
+    deps:
+      - "corpus/dev.spacy"
+      - "training/model-best"
+    outputs:
+      - "training/metrics.json"
+
+  - name: package
+    help: "Package the trained model as a pip package"
+    script:
+      - "python -m spacy package training/model-best packages --name ${vars.name} --version ${vars.version} --force"
+    deps:
+      - "training/model-best"
+    outputs_no_cache:
+      - "packages/${vars.lang}_${vars.name}-${vars.version}/dist/${vars.lang}_${vars.name}-${vars.version}.tar.gz"

--- a/pipelines/spancat_demo/project.yml
+++ b/pipelines/spancat_demo/project.yml
@@ -74,7 +74,7 @@ commands:
   - name: "train"
     help: "Train the spancat model"
     script:
-      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 50 --gpu-id ${vars.gpu_id}"
+      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 500 --gpu-id ${vars.gpu_id}"
     deps:
       - "configs/config.cfg"
       - "corpus/train.spacy"
@@ -85,7 +85,7 @@ commands:
   - name: "train-with-vectors"
     help: "Train the spancat model with vectors"
     script:
-      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 50 --gpu-id ${vars.gpu_id} --initialize.vectors ${vars.vectors_model} --components.tok2vec.model.embed.include_static_vectors true"
+      - "python -m spacy train configs/config.cfg --output training/ --paths.train corpus/train.spacy --paths.dev corpus/dev.spacy --training.eval_frequency 10 --training.patience 1500 --gpu-id ${vars.gpu_id} --initialize.vectors ${vars.vectors_model} --components.tok2vec.model.embed.include_static_vectors true"
     deps:
       - "configs/config.cfg"
       - "corpus/train.spacy"

--- a/pipelines/spancat_demo/scripts/convert.py
+++ b/pipelines/spancat_demo/scripts/convert.py
@@ -11,7 +11,7 @@ from spacy.tokens import DocBin
 
 def convert(lang: str, input_path: Path, output_path: Path, spans_key: str = "sc"):
     nlp = spacy.blank(lang)
-    db = DocBin()
+    doc_bin = DocBin()
     for text, annot in srsly.read_json(input_path):
         doc = nlp.make_doc(text)
         spans = []
@@ -23,8 +23,8 @@ def convert(lang: str, input_path: Path, output_path: Path, spans_key: str = "sc
             else:
                 spans.append(span)
         doc.spans[spans_key] = spans
-        db.add(doc)
-    db.to_disk(output_path)
+        doc_bin.add(doc)
+    doc_bin.to_disk(output_path)
 
 
 if __name__ == "__main__":

--- a/pipelines/spancat_demo/scripts/convert.py
+++ b/pipelines/spancat_demo/scripts/convert.py
@@ -1,0 +1,31 @@
+"""Convert entity annotation from spaCy v2 TRAIN_DATA format to spaCy v3
+.spacy format."""
+import srsly
+import typer
+import warnings
+from pathlib import Path
+
+import spacy
+from spacy.tokens import DocBin
+
+
+def convert(lang: str, input_path: Path, output_path: Path, spans_key: str = "sc"):
+    nlp = spacy.blank(lang)
+    db = DocBin()
+    for text, annot in srsly.read_json(input_path):
+        doc = nlp.make_doc(text)
+        spans = []
+        for start, end, label in annot["entities"]:
+            span = doc.char_span(start, end, label=label)
+            if span is None:
+                msg = f"Skipping entity [{start}, {end}, {label}] in the following text because the character span '{doc.text[start:end]}' does not align with token boundaries:\n\n{repr(text)}\n"
+                warnings.warn(msg)
+            else:
+                spans.append(span)
+        doc.spans[spans_key] = spans
+        db.add(doc)
+    db.to_disk(output_path)
+
+
+if __name__ == "__main__":
+    typer.run(convert)

--- a/pipelines/spancat_demo/test_project_spancat_demo.py
+++ b/pipelines/spancat_demo/test_project_spancat_demo.py
@@ -7,4 +7,5 @@ def test_spancat_demo_project():
     root = Path(__file__).parent
     project_assets(root)
     project_run(root, "all", capture=True)
+    project_run(root, "all-vectors", capture=True)
     project_run(root, "package", capture=True)

--- a/pipelines/spancat_demo/test_project_spancat_demo.py
+++ b/pipelines/spancat_demo/test_project_spancat_demo.py
@@ -1,0 +1,10 @@
+from spacy.cli.project.run import project_run
+from spacy.cli.project.assets import project_assets
+from pathlib import Path
+
+
+def test_spancat_demo_project():
+    root = Path(__file__).parent
+    project_assets(root)
+    project_run(root, "all", capture=True)
+    project_run(root, "package", capture=True)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,6 +1,6 @@
 <a href="https://explosion.ai"><img src="https://explosion.ai/assets/img/logo.svg" width="125" height="125" align="right" /></a>
 
-# 🪐 Project Templates: Tutorials (12)
+# 🪐 Project Templates: Tutorials (13)
 
 | Template | Description |
 | --- | --- |


### PR DESCRIPTION
## Description

cf. https://github.com/explosion/spaCy/discussions/9635, https://github.com/explosion/spaCy/discussions/11517, https://github.com/explosion/spaCy/discussions/11518

This PR adds a minimal `spancat_demo` project that demonstrates how to convert and train a `spancat` pipeline. It borrows heavily from the `ner_demo` project (the dummy data, command organization, etc.), with minimal changes (conversion script, config, etc.)

## Types of change

Enhancement

## Checklist

- [x]  I confirm that I have the right to submit this contribution under the project's MIT license.
- [x]  I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
