### PR TITLE
Change GoEmotions to use spacy assemble

### DIFF
--- a/tutorials/textcat_goemotions/README.md
+++ b/tutorials/textcat_goemotions/README.md
@@ -115,7 +115,7 @@ To make your own config to combine pipelines, the basic steps are:
 1. Include all the components you want in `nlp.pipeline`
 2. Add a section for each component, specifying the pipeline to source it from.
 3. If you have two components of the same type, specify unqiue component names for each.
-4. If necessary, specify `replace_listeners` to bundle a component with its tok2vec.
+4. If necessary, [specify `replace_listeners`](https://spacy.io/api/language#replace_listeners) to bundle a component with its tok2vec.
 
 You can also remove many values related to training - since you aren't running
 a training loop with `spacy assemble`, default values are fine.
@@ -135,13 +135,12 @@ final pipeline is from the same pipeline as the component you're adding, then
 you don't have to do anything. But if a component has a different tok2vec, you
 can bundle a standalone copy of the original tok2vec with the component so that it doesn't use the wrong one.
 
-Here's an example of a component that has a different name than it had
-originally, and also uses `replace_listeners`:
+Here's an example of a component where the name has changed from `ner` to `renamed_ner`, and also uses `replace_listeners`:
 
 ```ini
-[components.my_ner]
+[components.renamed_ner]
 source = "my_pipeline"
-# this component was just called "ner" originally
+# the "ner" here is the name in the base pipeline
 name = "ner"
 # and it listened to the "tok2vec" in the original pipeline
 replace_listeners = ["model.tok2vec"]

--- a/tutorials/textcat_goemotions/README.md
+++ b/tutorials/textcat_goemotions/README.md
@@ -106,8 +106,11 @@ assemble`](https://spacy.io/api/cli#assemble) - you'll just need to prepare a
 config describing your final pipeline.
 
 A sample config for doing this is included in
-`configs/cnn_with_pretrained.cfg`. The basic way to build a config for `spacy
-assemble` is to:
+`configs/cnn_with_pretrained.cfg`. After training the model in this project,
+you can combine it with a pretrained pipeline by running `spacy project run
+assemble`, which will save the new pipeline to `cnn_with_pretrained/`. 
+
+To make your own config to combine pipelines, the basic steps are:
 
 1. Include all the components you want in `nlp.pipeline`
 2. Add a section for each component, specifying the pipeline to source it from.
@@ -120,10 +123,11 @@ a training loop with `spacy assemble`, default values are fine.
 Let's go over the last two steps in a little more detail.
 
 By default, components have a simple default name in the pipeline, like "ner"
-or "textcat". However if you have two copies of a component they need to have
-different names. If you need to change the name of a component you can do that
-by giving it a different name in `nlp.pipeline`, and specifying the name in the
-original pipeline using the `name` value in the section for the component.
+or "textcat". However, if you have two copies of a component, then they need to
+have different names. If you need to change the name of a component you can do
+that by giving it a different name in `nlp.pipeline`, and specifying the name
+in the original pipeline using the `name` value in the section for the
+component.
 
 It depends on the pipeline, but often components use a Listener to just look
 for a tok2vec (or transformer) to get features from. If the tok2vec in your

--- a/tutorials/textcat_goemotions/README.md
+++ b/tutorials/textcat_goemotions/README.md
@@ -114,7 +114,7 @@ To make your own config to combine pipelines, the basic steps are:
 
 1. Include all the components you want in `nlp.pipeline`
 2. Add a section for each component, specifying the pipeline to source it from.
-3. If you have two components of the same type, specify the component names correctly.
+3. If you have two components of the same type, specify unqiue component names for each.
 4. If necessary, specify `replace_listeners` to bundle a component with its tok2vec.
 
 You can also remove many values related to training - since you aren't running
@@ -133,7 +133,7 @@ It depends on the pipeline, but often components use a Listener to just look
 for a tok2vec (or transformer) to get features from. If the tok2vec in your
 final pipeline is from the same pipeline as the component you're adding, then
 you don't have to do anything. But if a component has a different tok2vec, you
-can bundle the tok2vec with the component so that it doesn't use the wrong one.
+can bundle a standalone copy of the original tok2vec with the component so that it doesn't use the wrong one.
 
 Here's an example of a component that has a different name than it had
 originally, and also uses `replace_listeners`:

--- a/tutorials/textcat_goemotions/configs/cnn_with_pretrained.cfg
+++ b/tutorials/textcat_goemotions/configs/cnn_with_pretrained.cfg
@@ -1,0 +1,53 @@
+[paths]
+train = null
+dev = null
+# A handy variable to control the base pipeline
+source = "en_core_web_sm"
+
+[system]
+gpu_allocator = null
+
+[nlp]
+lang = "en"
+pipeline = ["tok2vec", "tagger", "parser", "attribute_ruler", "lemmatizer", "ner", "textcat"]
+batch_size = 1000
+
+[components]
+
+[components.textcat]
+# This is the component we just trained
+source = "training/cnn/model-best"
+# This should use the tok2vec it was trained with
+replace_listeners = ["model.tok2vec"]
+
+# the rest of the components are just sourced from the original pipeline
+[components.tok2vec]
+source = ${paths.source}
+
+[components.tagger]
+source = ${paths.source}
+
+[components.parser]
+source = ${paths.source}
+
+[components.attribute_ruler]
+source = ${paths.source}
+
+[components.lemmatizer]
+source = ${paths.source}
+
+[components.ner]
+source = ${paths.source}
+
+[corpora]
+
+[corpora.dev]
+@readers = "spacy.Corpus.v1"
+path = ${paths:dev}
+max_length = 0
+
+[corpora.train]
+@readers = "spacy.Corpus.v1"
+path = ${paths:train}
+max_length = 0
+

--- a/tutorials/textcat_goemotions/configs/cnn_with_pretrained.cfg
+++ b/tutorials/textcat_goemotions/configs/cnn_with_pretrained.cfg
@@ -20,7 +20,7 @@ source = "training/cnn/model-best"
 # This should use the tok2vec it was trained with
 replace_listeners = ["model.tok2vec"]
 
-# the rest of the components are just sourced from the original pipeline
+# the rest of the components are just sourced from the base pipeline
 [components.tok2vec]
 source = ${paths.source}
 

--- a/tutorials/textcat_goemotions/project.yml
+++ b/tutorials/textcat_goemotions/project.yml
@@ -106,3 +106,10 @@ commands:
     deps:
       - "scripts/visualize_model.py"
       - "training/${vars.config}/model-best"
+
+  - name: assemble
+    help: Combine the model with a pretrained pipeline.
+    script:
+      - "python -m spacy assemble configs/cnn_with_pretrained.cfg cnn_with_pretrained"
+    deps:
+      - "training/cnn/model-best"


### PR DESCRIPTION
In the GoEmotions project, there was a section on combining components from a pretrained pipeline. The method used was including components in your training config but disabling them. But since we have `spacy assemble` now, that allows you to keep your training config unmodified, and just use a separate config for `assemble`. 

This rewrites that section fo the README to use `spacy assemble`. It includes a sample config for use with assemble and explains how to make a config like that for your own pipeline.