### PR TITLE
Update Transformer architecture in example projects

### DIFF
--- a/benchmarks/healthsea_spancat/configs/spancat/config_trf.cfg
+++ b/benchmarks/healthsea_spancat/configs/spancat/config_trf.cfg
@@ -26,7 +26,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 
 [components.transformer.model.get_spans]

--- a/benchmarks/ner_conll03/configs/transformer.cfg
+++ b/benchmarks/ner_conll03/configs/transformer.cfg
@@ -48,7 +48,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 
 [components.transformer.model.get_spans]

--- a/benchmarks/parsing_penn_treebank/configs/transformer.cfg
+++ b/benchmarks/parsing_penn_treebank/configs/transformer.cfg
@@ -62,7 +62,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 
 [components.transformer.model.get_spans]

--- a/tutorials/ner_pytorch_medical/configs/config_trf.cfg
+++ b/tutorials/ner_pytorch_medical/configs/config_trf.cfg
@@ -26,7 +26,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 tokenizer_config = {"use_fast": true}
 

--- a/tutorials/ner_pytorch_medical/configs/spacy_config_trf.cfg
+++ b/tutorials/ner_pytorch_medical/configs/spacy_config_trf.cfg
@@ -46,7 +46,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 
 [components.transformer.model.get_spans]

--- a/tutorials/rel_component/configs/rel_trf.cfg
+++ b/tutorials/rel_component/configs/rel_trf.cfg
@@ -26,7 +26,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 tokenizer_config = {"use_fast": true}
 

--- a/tutorials/textcat_goemotions/configs/bert.cfg
+++ b/tutorials/textcat_goemotions/configs/bert.cfg
@@ -42,7 +42,7 @@ max_batch_items = 4096
 set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v3"
 name = "roberta-base"
 
 [components.transformer.model.get_spans]


### PR DESCRIPTION
Several projects were using `TransformerModel.v1`, but the latest model is v3. This shouldn't affect any of the projects as written, but if a user modifies a config to make a pipeline of their own, they may run into bugs we fixed a while ago without realizing why. 

This just updates the architectures. Leaving in draft until everything has been run for testing (locally, in addition to auto tests). 