### PR TITLE
move comment on assets

### DIFF
--- a/benchmarks/speed/project.yml
+++ b/benchmarks/speed/project.yml
@@ -17,10 +17,6 @@ vars:
 # sure that they always exist.
 directories: ["scripts", "texts", "results"]
 
-# Assets that should be downloaded or available in the directory. We're shipping
-# some of them with the project, so they won't have to be downloaded. But the
-# 'project assets' command still lets you verify that the checksums match.
-
 # Workflows are sequences of commands (see below) executed in order. You can
 # run them via "spacy project run [workflow]". If a commands's inputs/outputs
 # haven't changed, it won't be re-run.
@@ -32,6 +28,9 @@ workflows:
     - timing_cpu
     - timing_gpu
 
+# Assets that should be downloaded or available in the directory. We're shipping
+# some of them with the project, so they won't have to be downloaded. But the
+# 'project assets' command still lets you verify that the checksums match.
 assets:
   -
     dest: "texts/reddit-100k.jsonl"


### PR DESCRIPTION
In the speed benchmark project, the comment about the assets got moved away from the actual definition of the assets - putting it back for clarity for those reading the `yml` file manually ;-) 