### PR TITLE
Add automatic doc building

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:  # allow manual trigger
   schedule:
     - cron: '0 8 * * 5'  # every Friday at 8am UTC
+  push: # TEMP
 
 jobs:
   autodoc:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
       - name: Build Docs
         run: |
+          pip install spacy
           python .github/update_docs.py
           python .github/update_category_docs.py
           python .github/update_projects_json.py

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:  # allow manual trigger
   schedule:
     - cron: '0 8 * * 5'  # every Friday at 8am UTC
-  push: # TEMP
 
 jobs:
   autodoc:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,8 @@ jobs:
           pip install spacy
           python .github/update_docs.py
           python .github/update_category_docs.py
-          python .github/update_projects_json.py
+          # Temporarily commented out while PR is reviewed
+          # python .github/update_projects_json.py
       - name: Check for modified files
         id: git-check
         run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,44 @@
+# GitHub Action that builds docs regularly
+
+name: Build Docs
+on:
+  workflow_dispatch:  # allow manual trigger
+  schedule:
+    - cron: '0 8 * * 5'  # every Friday at 8am UTC
+
+jobs:
+  autodoc:
+    if: github.repository_owner == 'explosion'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            ref: ${{ github.head_ref }}
+      - uses: actions/setup-python@v4
+      - name: Auto-format code if needed
+        run: |
+          python .github/update_docs.py
+          python .github/update_category_docs.py
+          python .github/update_projects_json.py
+      - name: Check for modified files
+        id: git-check
+        run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.modified == 'true'
+        uses: peter-evans/create-pull-request@v4
+        with:
+            title: Automated build of docs
+            labels: meta
+            commit-message: Automated docs build 
+            committer: GitHub <noreply@github.com>
+            author: explosion-bot <explosion-bot@users.noreply.github.com>
+            body: _This PR is auto-generated._
+            branch: docs-build
+            delete-branch: true
+            draft: false
+      - name: Check outputs
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
         with:
             ref: ${{ github.head_ref }}
       - uses: actions/setup-python@v4
-      - name: Auto-format code if needed
+      - name: Build Docs
         run: |
           python .github/update_docs.py
           python .github/update_category_docs.py


### PR DESCRIPTION
## Description

This is a script to automatically run update scripts once a week, just like the autoblack job in spaCy.

Currently the config update script (`update_configs.py`) is not included. One reason is that config changes require more review, another is that there may be cases where we don't want configs auto-filled. Another reason is that currently the script just fails with an error on some projects, which needs to be checked separately.

<!--- Provide a general summary of your changes in the title. -->


<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

automation

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] I ran the `update` scripts in the `.github` folder, and all the configs and docs are up-to-date.
