### PR TITLE
Demo project for edit-tree lemmatizer

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,9 +1,10 @@
 <a href="https://explosion.ai"><img src="https://explosion.ai/assets/img/logo.svg" width="125" height="125" align="right" /></a>
 
-# 🪐 Project Templates: Pipelines (16)
+# 🪐 Project Templates: Pipelines (17)
 
 | Template | Description |
 | --- | --- |
+| [`edit_tree_lemmatizer`](edit_tree_lemmatizer) | Demo the trainable edit-tree lemmatizer |
 | [`floret_fi_core_demo`](floret_fi_core_demo) | Demo floret vectors for Finnish |
 | [`floret_ko_ud_demo`](floret_ko_ud_demo) | Demo floret vectors for UD Korean Kaist |
 | [`floret_vectors_demo`](floret_vectors_demo) | Demo floret vectors |

--- a/pipelines/edit_tree_lemmatizer/.gitignore
+++ b/pipelines/edit_tree_lemmatizer/.gitignore
@@ -1,0 +1,4 @@
+assets
+configs
+corpus
+training

--- a/pipelines/edit_tree_lemmatizer/README.md
+++ b/pipelines/edit_tree_lemmatizer/README.md
@@ -1,0 +1,45 @@
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS START (do not remove) -->
+
+# 🪐 spaCy Project: Edit tree lemmatizer
+
+## 📋 project.yml
+
+The [`project.yml`](project.yml) defines the data assets required by the
+project, as well as the available commands and workflows. For details, see the
+[spaCy projects documentation](https://spacy.io/usage/projects).
+
+### ⏯ Commands
+
+The following commands are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run).
+Commands are only re-run if their inputs have changed.
+
+| Command | Description |
+| --- | --- |
+| `preprocess` | Convert data to spaCy format |
+| `create-config` | Create a config |
+| `train` | Train the lemmatizer |
+| `evaluate` | Evaluate the lemmatization model evaluate on the test corpus. |
+
+### ⏭ Workflows
+
+The following workflows are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run)
+and will run the specified commands in order. Commands are only re-run if their
+inputs have changed.
+
+| Workflow | Steps |
+| --- | --- |
+| `all` | `preprocess` &rarr; `create-config` &rarr; `train` &rarr; `evaluate` |
+
+### 🗂 Assets
+
+The following assets are defined by the project. They can
+be fetched by running [`spacy project assets`](https://spacy.io/api/cli#project-assets)
+in the project directory.
+
+| File | Source | Description |
+| --- | --- | --- |
+| `assets/UD_Dutch-Alpino` | Git |  |
+
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/pipelines/edit_tree_lemmatizer/project.yml
+++ b/pipelines/edit_tree_lemmatizer/project.yml
@@ -1,0 +1,66 @@
+title: "Edit tree lemmatizer"
+
+vars:
+  lang: "nl"
+  treebank: "UD_Dutch-Alpino"
+  train_name: "nl_alpino-ud-train"
+  dev_name: "nl_alpino-ud-dev"
+  test_name: "nl_alpino-ud-test"
+  gpu: -1
+
+directories: ["configs", "assets", "corpus", "training"]
+
+assets:
+  - dest: "assets/${vars.treebank}"
+    git:
+      repo: "https://github.com/UniversalDependencies/${vars.treebank}"
+      branch: "master"
+      path: ""
+
+workflows:
+  all:
+    - preprocess
+    - create-config
+    - train
+    - evaluate
+
+commands:
+  - name: "preprocess"
+    help: "Convert data to spaCy format"
+    script:
+      - "mkdir -p corpus/${vars.treebank}"
+      - "python -m spacy convert assets/${vars.treebank}/${vars.train_name}.conllu corpus/${vars.treebank}/ --n-sents 10"
+      - "mv corpus/${vars.treebank}/${vars.train_name}.spacy corpus/${vars.treebank}/train.spacy"
+      - "python -m spacy convert assets/${vars.treebank}/${vars.dev_name}.conllu corpus/${vars.treebank}/ --n-sents 10"
+      - "mv corpus/${vars.treebank}/${vars.dev_name}.spacy corpus/${vars.treebank}/dev.spacy"
+      - "python -m spacy convert assets/${vars.treebank}/${vars.test_name}.conllu corpus/${vars.treebank}/ --n-sents 10"
+      - "mv corpus/${vars.treebank}/${vars.test_name}.spacy corpus/${vars.treebank}/test.spacy"
+    deps:
+      - "assets/${vars.treebank}/"
+    outputs:
+      - "corpus/${vars.treebank}/train.spacy"
+      - "corpus/${vars.treebank}/dev.spacy"
+      - "corpus/${vars.treebank}/test.spacy"
+
+  - name: "create-config"
+    help: "Create a config"
+    script:
+      - "python -m spacy init config -l ${vars.lang} -p trainable_lemmatizer configs/${vars.treebank}/config.cfg -F"
+
+  - name: "train"
+    help: "Train the lemmatizer"
+    script:
+      - "python -m spacy train configs/${vars.treebank}/config.cfg --output training/${vars.treebank} --gpu-id ${vars.gpu} --paths.train corpus/${vars.treebank}/train.spacy --paths.dev corpus/${vars.treebank}/dev.spacy"
+    deps:
+      - "configs/${vars.treebank}/config.cfg"
+      - "corpus/${vars.treebank}/train.spacy"
+      - "corpus/${vars.treebank}/dev.spacy"
+    outputs:
+      - "training/${vars.treebank}/model-best"
+
+  - name: "evaluate"
+    help: "Evaluate the lemmatization model evaluate on the test corpus."
+    script:
+      - "python -m spacy evaluate training/${vars.treebank}/model-best corpus/${vars.treebank}/test.spacy"
+    deps:
+      - "training/${vars.treebank}/model-best"

--- a/pipelines/edit_tree_lemmatizer/project.yml
+++ b/pipelines/edit_tree_lemmatizer/project.yml
@@ -1,4 +1,4 @@
-title: "Edit tree lemmatizer"
+title: "Demo the trainable edit-tree lemmatizer"
 
 vars:
   lang: "nl"

--- a/pipelines/edit_tree_lemmatizer/test_project_etl.py
+++ b/pipelines/edit_tree_lemmatizer/test_project_etl.py
@@ -1,0 +1,9 @@
+from spacy.cli.project.run import project_run
+from spacy.cli.project.assets import project_assets
+from pathlib import Path
+
+
+def test_etl_project():
+    root = Path(__file__).parent
+    project_assets(root)
+    project_run(root, "all", capture=True)


### PR DESCRIPTION
## Description

It looks like the [project](https://github.com/explosion/spacy-experimental/tree/v0.4.0/projects/edit_tree_lemmatizer) for the experimental edit-tree lemmatizer was removed when moving the functionality to spaCy. Moving it back to the "pipelines" directory here, as I think it's still a nice demo project to showcase how the lemmatizer trains/works.

Adjusted the project to refer to the `trainable_lemmatizer` component and tested to work with spaCy 3.5.

### Types of change

feature

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] I ran the `update` scripts in the `.github` folder, and all the configs and docs are up-to-date.
