### PR TITLE
NEL benchmark: update spaCy version

### DIFF
--- a/benchmarks/nel/project.yml
+++ b/benchmarks/nel/project.yml
@@ -1,6 +1,6 @@
 title: 'NEL Benchmark'
 description: "Pipeline for benchmarking NEL approaches (incl. candidate generation and entity disambiguation)."
-spacy_version: ">=3.0.0,<3.5.0"
+spacy_version: ">=3.5.0,<3.6.0"
 vars:
   run: "cg-default"
   language: "en"

--- a/benchmarks/nel/project.yml
+++ b/benchmarks/nel/project.yml
@@ -1,6 +1,6 @@
 title: 'NEL Benchmark'
 description: "Pipeline for benchmarking NEL approaches (incl. candidate generation and entity disambiguation)."
-spacy_version: ">=3.5.0,<3.6.0"
+spacy_version: ">=3.0.0,<3.6.0"
 vars:
   run: "cg-default"
   language: "en"

--- a/benchmarks/nel/scripts/candidate_generation/base.py
+++ b/benchmarks/nel/scripts/candidate_generation/base.py
@@ -8,7 +8,7 @@ from spacy import Language
 from spacy.kb import Candidate
 from spacy.tokens import Span
 
-from ..compat import KnowledgeBase
+from compat import KnowledgeBase
 from datasets.dataset import Dataset
 
 

--- a/benchmarks/nel/scripts/candidate_generation/base.py
+++ b/benchmarks/nel/scripts/candidate_generation/base.py
@@ -5,9 +5,10 @@ from typing import Dict, Any, Optional, Iterable, Tuple
 
 import spacy
 from spacy import Language
-from spacy.kb import KnowledgeBase, Candidate
+from spacy.kb import Candidate
 from spacy.tokens import Span
 
+from ..compat import KnowledgeBase
 from datasets.dataset import Dataset
 
 

--- a/benchmarks/nel/scripts/candidate_generation/embeddings.py
+++ b/benchmarks/nel/scripts/candidate_generation/embeddings.py
@@ -6,7 +6,7 @@ from sklearn.neighbors import NearestNeighbors
 
 from spacy.tokens import Span
 from .base import NearestNeighborCandidateSelector
-from ..compat import KnowledgeBase
+from compat import KnowledgeBase
 from rapidfuzz.string_metric import normalized_levenshtein
 
 

--- a/benchmarks/nel/scripts/candidate_generation/embeddings.py
+++ b/benchmarks/nel/scripts/candidate_generation/embeddings.py
@@ -1,13 +1,12 @@
 """ Candidate generation via distance in embedding space. """
-import time
 from typing import Iterable, List, Set
 
 import numpy
 from sklearn.neighbors import NearestNeighbors
 
-from spacy.kb import KnowledgeBase
 from spacy.tokens import Span
 from .base import NearestNeighborCandidateSelector
+from ..compat import KnowledgeBase
 from rapidfuzz.string_metric import normalized_levenshtein
 
 

--- a/benchmarks/nel/scripts/candidate_generation/lexical.py
+++ b/benchmarks/nel/scripts/candidate_generation/lexical.py
@@ -3,7 +3,7 @@ from typing import Iterable
 
 from spacy.tokens import Span
 from .base import NearestNeighborCandidateSelector
-from ..compat import KnowledgeBase
+from compat import KnowledgeBase
 from cfuzzyset import cFuzzySet as FuzzySet
 
 

--- a/benchmarks/nel/scripts/candidate_generation/lexical.py
+++ b/benchmarks/nel/scripts/candidate_generation/lexical.py
@@ -1,9 +1,9 @@
 """ Candidate generation via distance in lexical space. """
 from typing import Iterable
 
-from spacy.kb import KnowledgeBase, Candidate
 from spacy.tokens import Span
 from .base import NearestNeighborCandidateSelector
+from ..compat import KnowledgeBase
 from cfuzzyset import cFuzzySet as FuzzySet
 
 

--- a/benchmarks/nel/scripts/compat.py
+++ b/benchmarks/nel/scripts/compat.py
@@ -1,0 +1,4 @@
+try:
+    from spacy.kb import InMemoryLookupKB as KnowledgeBase
+except ImportError:
+    from spacy.kb import KnowledgeBase as KnowledgeBase

--- a/benchmarks/nel/scripts/custom_functions.py
+++ b/benchmarks/nel/scripts/custom_functions.py
@@ -4,9 +4,10 @@ from functools import partial
 from typing import Iterable, Callable
 import typing
 import spacy
-from spacy.kb import Candidate, KnowledgeBase
+from spacy.kb import Candidate
 from spacy.tokens import Span
 
+from .compat import KnowledgeBase
 from scripts.candidate_generation import embeddings
 from scripts.candidate_generation import lexical
 

--- a/benchmarks/nel/scripts/custom_functions.py
+++ b/benchmarks/nel/scripts/custom_functions.py
@@ -7,7 +7,7 @@ import spacy
 from spacy.kb import Candidate
 from spacy.tokens import Span
 
-from .compat import KnowledgeBase
+from compat import KnowledgeBase
 from scripts.candidate_generation import embeddings
 from scripts.candidate_generation import lexical
 

--- a/benchmarks/nel/scripts/datasets/dataset.py
+++ b/benchmarks/nel/scripts/datasets/dataset.py
@@ -24,7 +24,7 @@ from spacy.pipeline import EntityLinker
 
 from wikid import schemas
 from . import evaluation
-from ..compat import KnowledgeBase
+from compat import KnowledgeBase
 from utils import get_logger
 
 logger = get_logger(__name__)

--- a/benchmarks/nel/scripts/datasets/dataset.py
+++ b/benchmarks/nel/scripts/datasets/dataset.py
@@ -17,7 +17,6 @@ import spacy
 import tqdm
 import yaml
 from spacy import Language
-from spacy.kb import KnowledgeBase
 from spacy.pipeline.legacy import EntityLinker_v1
 from spacy.tokens import Doc, DocBin
 from spacy.training import Example
@@ -25,6 +24,7 @@ from spacy.pipeline import EntityLinker
 
 from wikid import schemas
 from . import evaluation
+from ..compat import KnowledgeBase
 from utils import get_logger
 
 logger = get_logger(__name__)

--- a/benchmarks/nel/scripts/datasets/evaluation.py
+++ b/benchmarks/nel/scripts/datasets/evaluation.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple, Optional
 
 import prettytable
-from spacy.kb import KnowledgeBase, Candidate
+from spacy.kb import Candidate
 from spacy.tokens import Doc
 from utils import get_logger
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Recent [commits show CI failures](https://dev.azure.com/explosion-ai/Public/_build/results?buildId=23901&view=logs&j=f1d52934-b974-5ece-337e-e658a4411382&t=25745add-d8f1-5bdf-c7de-2e51e93603d8) caused by `wikid` importing `InMemoryLookupKB`.  This is unexpected, as this error has [been accounted for in `wikid` already](https://github.com/explosion/wikid/blob/main/scripts/create_kb.py#L12). 
The NEL benchmark itself hasn't been adjusted accordingly yet anyway, so this PR aims to support spacy>=3.0.0,<3.6.0 by relaxing the requirement in the project file and importing the correct KB class contingent on the spaCy version.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Fix.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] I ran the `update` scripts in the `.github` folder, and all the configs and docs are up-to-date.
