### PR TITLE
Update ner_spancat_compare for newer spacy, doc/vocab issues

### DIFF
--- a/experimental/ner_spancat_compare/configs/ner_assemble.cfg
+++ b/experimental/ner_spancat_compare/configs/ner_assemble.cfg
@@ -55,23 +55,23 @@ component = "ner"
 # Then, we instantiate a component from our `transfer-ent` factory so that
 # we can move the entities in doc.ents into doc.spans.
 [components.transfer-dna]
-factory = "transfer-ent.v1"
+factory = "transfer-ent"
 span_key = ${paths.spans_key}
 
 [components.transfer-rna]
-factory = "transfer-ent.v1"
+factory = "transfer-ent"
 span_key = ${paths.spans_key}
 
 [components.transfer-cell-line]
-factory = "transfer-ent.v1"
+factory = "transfer-ent"
 span_key = ${paths.spans_key}
 
 [components.transfer-cell-type]
-factory = "transfer-ent.v1"
+factory = "transfer-ent"
 span_key = ${paths.spans_key}
 
 [components.transfer-protein]
-factory = "transfer-ent.v1"
+factory = "transfer-ent"
 span_key = ${paths.spans_key}
 
 

--- a/experimental/ner_spancat_compare/scripts/convert.py
+++ b/experimental/ner_spancat_compare/scripts/convert.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import List
 
 import typer
-from spacy.tokens import Doc, DocBin, SpanGroup
+from spacy.tokens import Doc, DocBin, Span, SpanGroup
 from spacy.training.converters import conll_ner_to_docs
 from wasabi import msg
 
@@ -46,8 +46,11 @@ def convert_iob_to_docs(
     docs_with_spans: List[Doc] = []
 
     for docs in zip(*docs_per_level):
-        spans = [ent for doc in docs for ent in doc.ents]
         doc = docs[0]
+        # recreate all spans for the same underlying doc
+        spans = []
+        for span in [ent for doc in docs for ent in doc.ents]:
+            spans.append(Span(doc, span.start, span.end, span.label_))
         group = SpanGroup(doc, name=spans_key, spans=spans)
         doc.spans[spans_key] = group
         docs_with_spans.append(doc)

--- a/experimental/ner_spancat_compare/scripts/transfer_ent_component.py
+++ b/experimental/ner_spancat_compare/scripts/transfer_ent_component.py
@@ -3,7 +3,7 @@ from spacy.tokens import Doc
 from spacy.tokens.span_group import SpanGroup
 
 
-@Language.factory("transfer-ent.v1", requires=["doc._.ents"])
+@Language.factory("transfer-ent", requires=["doc._.ents"])
 def make_transfer_component(nlp: Language, name: str, span_key: str):
     return TransferEntComponent(nlp, name, span_key)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

* Rename component to `transfer-ent` to avoid `.` in factory name (for spacy v3.4.2+)
* In convert script, make sure all spans belong to the same doc object when initializing span groups. Otherwise there can be cases where the span label is not in the doc vocab.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] I ran the `update` scripts in the `.github` folder, and all the configs and docs are up-to-date.
